### PR TITLE
Additional wrappers to SLICOT functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 Slycot
 =============
 
-.. image:: https://travis-ci.org/jgoppert/Slycot.svg
-        :target: https://travis-ci.org/jgoppert/Slycot
-.. image:: https://coveralls.io/repos/jgoppert/Slycot/badge.png
-        :target: https://coveralls.io/r/jgoppert/Slycot
+.. image:: https://travis-ci.org/python-control/Slycot.svg?branch=master
+        :target: https://travis-ci.org/python-control/Slycot
+.. image:: https://coveralls.io/repos/python-control/Slycot/badge.png
+        :target: https://coveralls.io/r/python-control/Slycot
 
 Python wrapper for selected SLICOT routines, notably including solvers for
 Riccati, Lyapunov and Sylvester equations.

--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -25,8 +25,8 @@ else:
     # Mathematical routines (3/81 wrapped)
     from .math import mc01td, mb05md, mb05nd
 
-    # Synthesis routines (11/50 wrapped)
-    from .synthesis import sb01bd,sb02md,sb02mt,sb02od,sb03md
+    # Synthesis routines (12/50 wrapped)
+    from .synthesis import sb01bd,sb02md,sb02mt,sb02od,sb03md,sb03od
     from .synthesis import sb04md,sb04qd,sb10ad,sb10hd,sg03ad
     from .synthesis import sg02ad
 

--- a/slycot/analysis.py
+++ b/slycot/analysis.py
@@ -876,7 +876,7 @@ def ab09bd(dico,job,equil,n,m,p,A,B,C,D,nr=None,tol1=0,tol2=0,ldwork=None):
         e = ArithmeticError('The computation of Hankel singular values failed')
         e.info = out[-1]
         raise e
-    nr,A,B,C,D,hsv = out[:-2]
+    Nr,A,B,C,D,hsv = out[:-2]
     return nr, A[:Nr,:Nr], B[:Nr,:], C[:,:Nr],D[:,:], hsv
 
 # to be replaced by python wrappers

--- a/slycot/src/analysis.pyf
+++ b/slycot/src/analysis.pyf
@@ -232,3 +232,29 @@ subroutine ab09ax(dico,job,ordsel,n,m,p,nr,a,lda,b,ldb,c,ldc,hsv,t,ldt,ti,ldti,t
     integer intent(out) :: iwarn
     integer intent(out) :: info
 end subroutine ab09ax
+subroutine ab09bd(dico,job,equil,ordsel,n,m,p,nr,a,lda,b,ldb,c,ldc,d,ldd,hsv,tol1,tol2,iwork,dwork,ldwork,iwarn,info) !in :balred:AB09BD.f
+    character intent(in) :: dico
+    character intent(in) :: job
+    character intent(in) :: equil
+    character intent(in) :: ordsel
+    integer check(n>=0) :: n
+    integer check(m>=0) :: m
+    integer check(p>=0) :: p
+    integer intent(in,out) :: nr
+    double precision intent(in,out,copy),dimension(n,n),depend(n) :: a
+    integer intent(hide),depend(a) :: lda=shape(a,0)
+    double precision intent(in,out,copy),dimension(n,m),depend(n,m) :: b
+    integer intent(hide),depend(b) :: ldb=shape(b,0)
+    double precision intent(in,out,copy),dimension(p,n),depend(n,p) :: c
+    integer intent(hide),depend(c) :: ldc=shape(c,0)
+    double precision intent(in,out,copy),dimension(p,m),depend(m,p) :: d
+    integer intent(hide),depend(d) :: ldd=shape(d,0)
+    double precision intent(out),dimension(n),depend(n) :: hsv
+    double precision :: tol1 =0.0
+    double precision :: tol2 =0.0
+    integer intent(hide,cache),dimension(max(m,p)) :: iwork
+    double precision intent(hide,cache),dimension(ldwork) :: dwork
+    integer optional :: ldwork = max(1,n*(2*n+max(n,max(m,p))+5)+n*(n+1)/2)
+    integer intent(out) :: iwarn
+    integer intent(out) :: info
+end subroutine ab09bd

--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -347,24 +347,24 @@ subroutine sb03md(dico,job,fact,trana,n,c,ldc,a,lda,u,ldu,scale,sep,ferr,wr,wi,i
     integer optional,check(ldwork>=max(2*n*n,3*n)),depend(n) :: ldwork=max(2*n*n,3*n)
     integer intent(out) :: info
 end subroutine sb03md
-subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info)
+subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info) ! in SB03OD.f
     fortranname sb03od
     character :: dico
     character :: fact='N'
     character :: trans='N'
     integer check(n>0) :: n
-    double precision dimension(n,n),depend(n) :: a
     integer check(m>0) :: m
+    double precision dimension(n,n),depend(n) :: a
     integer intent(hide),depend(a) :: lda=shape(a,0)
     double precision dimension(n,n),depend(n) :: q
     integer intent(hide),depend(q) :: ldq=shape(q,0)
-    double precision dimension(n,n),depend(n) :: b
+    double precision intent(in,out,copy),dimension(n,n),depend(n) :: b
     integer intent(hide),depend(b) :: ldb=shape(b,0)
     double precision intent(out) :: scale
     double precision intent(out),dimension(n),depend(n) :: wr
     double precision intent(out),dimension(n),depend(n) :: wi
     double precision intent(hide,cache),dimension(ldwork) :: dwork
-    integer optional,check(ldwork>=max(2*n*n,3*n)),depend(n) :: ldwork=max(2*n*n,3*n)
+    integer optional,check(ldwork>=max(1,4*n + min(m,n))),depend(n,m) :: ldwork=max(1,4*n + min(m,n))
     integer intent(out) :: info    
 end subroutine sb03od
 subroutine sb04md(n,m,a,lda,b,ldb,c,ldc,z,ldz,iwork,dwork,ldwork,info) ! in SB04MD.f

--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -348,7 +348,7 @@ subroutine sb03md(dico,job,fact,trana,n,c,ldc,a,lda,u,ldu,scale,sep,ferr,wr,wi,i
     integer intent(out) :: info
 end subroutine sb03md
 subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info)
-    fortranname sb030d
+    fortranname sb03od
     character :: dico
     character :: fact='N'
     character :: trans='N'

--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -347,6 +347,26 @@ subroutine sb03md(dico,job,fact,trana,n,c,ldc,a,lda,u,ldu,scale,sep,ferr,wr,wi,i
     integer optional,check(ldwork>=max(2*n*n,3*n)),depend(n) :: ldwork=max(2*n*n,3*n)
     integer intent(out) :: info
 end subroutine sb03md
+subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info)
+    fortranname sb030d
+    character :: dico
+    character :: fact='N'
+    character :: trans='N'
+    integer check(n>0) :: n
+    double precision dimension(n,n),depend(n) :: a
+    integer check(m>0) :: m
+    integer intent(hide),depend(a) :: lda=shape(a,0)
+    double precision dimension(n,n),depend(n) :: q
+    integer intent(hide),depend(q) :: ldq=shape(q,0)
+    double precision dimension(n,n),depend(n) :: b
+    integer intent(hide),depend(b) :: ldb=shape(b,0)
+    double precision intent(out) :: scale
+    double precision intent(out),dimension(n),depend(n) :: wr
+    double precision intent(out),dimension(n),depend(n) :: wi
+    double precision intent(hide,cache),dimension(ldwork) :: dwork
+    integer optional,check(ldwork>=max(2*n*n,3*n)),depend(n) :: ldwork=max(2*n*n,3*n)
+    integer intent(out) :: info    
+end subroutine sb03od
 subroutine sb04md(n,m,a,lda,b,ldb,c,ldc,z,ldz,iwork,dwork,ldwork,info) ! in SB04MD.f
     integer check(n>0) :: n
     integer check(m>0) :: m
@@ -410,13 +430,13 @@ subroutine sb10ad(job,n,m,np,ncon,nmeas,gamma,a,lda,b,ldb,c,ldc,d,ldd,ak,ldak,bk
     double precision intent(out), dimension(ncon,nmeas), depend(ncon,nmeas) :: dk
     integer intent(hide), depend(dk) :: lddk=shape(dk,0)
     double precision intent(out), dimension(2*n,2*n), depend(n) :: ac
-    integer intent(hide), depend(ac) :: ldac=shape(ac,0)
+    integer intent(hide), depend(ac) :: ldak=shape(ac,0)
     double precision intent(out), dimension(2*n,m-ncon), depend(n,m,ncon) :: bc
-    integer intent(hide), depend(bc) :: ldbc=shape(bc,0)
+    integer intent(hide), depend(bc) :: ldbk=shape(bc,0)
     double precision intent(out), dimension(np-nmeas,2*n), depend(np,nmeas,n) :: cc
-    integer intent(hide), depend(cc) :: ldcc=shape(cc,0)
+    integer intent(hide), depend(cc) :: ldck=shape(cc,0)
     double precision intent(out), dimension(np-nmeas,m-ncon), depend(np,nmeas,m,ncon) :: dc
-    integer intent(hide), depend(dc) :: lddc=shape(dc,0)
+    integer intent(hide), depend(dc) :: lddk=shape(dc,0)
     double precision intent(out), dimension(4) :: rcond
     double precision optional :: gtol=0.0
     double precision optional :: actol=0.0

--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -348,10 +348,14 @@ subroutine sb03md(dico,job,fact,trana,n,c,ldc,a,lda,u,ldu,scale,sep,ferr,wr,wi,i
     integer intent(out) :: info
 end subroutine sb03md
 <<<<<<< HEAD
+<<<<<<< HEAD
 subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info) ! in SB03OD.f
 =======
 subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info)
 >>>>>>> f1b51c5... Fixed sb03od bug in synthesis.pyf.
+=======
+subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info) ! in SB03OD.f
+>>>>>>> 47a3169... Added wrapper to SLICOT routine SB03OD.
     fortranname sb03od
     character :: dico
     character :: fact='N'

--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -347,7 +347,11 @@ subroutine sb03md(dico,job,fact,trana,n,c,ldc,a,lda,u,ldu,scale,sep,ferr,wr,wi,i
     integer optional,check(ldwork>=max(2*n*n,3*n)),depend(n) :: ldwork=max(2*n*n,3*n)
     integer intent(out) :: info
 end subroutine sb03md
+<<<<<<< HEAD
 subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info) ! in SB03OD.f
+=======
+subroutine sb03od(dico,fact,trans,n,m,a,lda,q,ldq,b,ldb,scale,wr,wi,dwork,ldwork,info)
+>>>>>>> f1b51c5... Fixed sb03od bug in synthesis.pyf.
     fortranname sb03od
     character :: dico
     character :: fact='N'

--- a/slycot/src/synthesis.pyf
+++ b/slycot/src/synthesis.pyf
@@ -430,13 +430,13 @@ subroutine sb10ad(job,n,m,np,ncon,nmeas,gamma,a,lda,b,ldb,c,ldc,d,ldd,ak,ldak,bk
     double precision intent(out), dimension(ncon,nmeas), depend(ncon,nmeas) :: dk
     integer intent(hide), depend(dk) :: lddk=shape(dk,0)
     double precision intent(out), dimension(2*n,2*n), depend(n) :: ac
-    integer intent(hide), depend(ac) :: ldak=shape(ac,0)
+    integer intent(hide), depend(ac) :: ldac=shape(ac,0)
     double precision intent(out), dimension(2*n,m-ncon), depend(n,m,ncon) :: bc
-    integer intent(hide), depend(bc) :: ldbk=shape(bc,0)
+    integer intent(hide), depend(bc) :: ldbc=shape(bc,0)
     double precision intent(out), dimension(np-nmeas,2*n), depend(np,nmeas,n) :: cc
-    integer intent(hide), depend(cc) :: ldck=shape(cc,0)
+    integer intent(hide), depend(cc) :: ldcc=shape(cc,0)
     double precision intent(out), dimension(np-nmeas,m-ncon), depend(np,nmeas,m,ncon) :: dc
-    integer intent(hide), depend(dc) :: lddk=shape(dc,0)
+    integer intent(hide), depend(dc) :: lddc=shape(dc,0)
     double precision intent(out), dimension(4) :: rcond
     double precision optional :: gtol=0.0
     double precision optional :: actol=0.0

--- a/slycot/synthesis.py
+++ b/slycot/synthesis.py
@@ -1033,9 +1033,9 @@ def sb03od(n,m,A,Q,B,dico,fact='N',trans='N',ldwork=None):
                 be destroyed.
     """
     hidden = ' (hidden by the wrapper)'
-    arg_list = ['dico','fact', 'trans', 'n', 'm', 'A', 'LDA'+hidden, 'Q',
-        'LDQ'+hidden, 'B', 'LDB'+hidden, 'scale', 'wr'+hidden,
-        'wi'+hidden, 'DWORK'+hidden, 'ldwork', 'INFO'+hidden]
+    arg_list = ['dico','fact', 'trans', 'n', 'm', 'a', 'lda'+hidden, 'q',
+        'ldq'+hidden, 'b', 'ldb'+hidden, 'scale', 'wr'+hidden,
+        'wi'+hidden, 'dwork'+hidden, 'ldwork', 'info'+hidden]
     if ldwork is None:
         if m > 0:
             ldwork = max(1,4*n + min(m,n))
@@ -1121,7 +1121,7 @@ def sb03od(n,m,A,Q,B,dico,fact='N',trans='N',ldwork=None):
         e = ValueError(error_text)
         e.info = out[-1]
         raise e
-    U,scale,wr,wi = out[-1]
+    U,scale,wr,wi = out[:-1]
     w = _np.zeros(n,'complex64')
     w.real = wr[0:n]
     w.imag = wi[0:n]

--- a/slycot/synthesis.py
+++ b/slycot/synthesis.py
@@ -882,7 +882,7 @@ converged Shur form'""" %(out[-1],n) # not sure about the indenting here
     return X,scale,sep,ferr,w
 
 def sb03od(n,m,A,Q,B,dico,fact='N',trans='N',ldwork=None):
-    """  U,scale,w = sb03od(dico,n,n,A,Q,B,[fact,trans,ldwork])
+    """  U,scale,w = sb03od(dico,n,m,A,Q,B,[fact,trans,ldwork])
 
     To solve for X = op(U)'*op(U) either the stable non-negative
     definite continuous-time Lyapunov equation


### PR DESCRIPTION
I've added wrappers to SLICOT functions SB03OD and AB09BD. I have an open pull request on jgoppert/Slycot, but that fork seems to be abandoned.