### PR TITLE
Use conda for building (and consequently drop Py 2.6, 3.2, add 3.4, 3.5).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,39 @@
+# cargo-culted from python-control's .travis.yml
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-# install required system libraries
-before_install:
-  - sudo apt-get update --fix-missing -qq
-  - sudo apt-get build-dep python-scipy -qq
-# command to install dependencies from source
-# note, separating requirements so that travis
-# will get output in less than 5 min and won't
-# terminate, using q to keep build info to a
-# minumum for dependencies
-install:
-  - while [[ 1 ]]; do echo "building deps"; sleep 300; done &
-  - msg_pid=$!
-  - pip install -q coverage
-  - pip install -q coveralls
-  - pip install -q nose scipy
-  - pip install -q scipy
-  - kill $msg_pid
 
-# command to run tests
-script: python runtests.py --coverage
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
+before_install:
+  - sudo apt-get install gfortran
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda install conda-build
+  - conda config --add channels http://conda.binstar.org/python-control
+  - conda info -a
+  - conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip coverage nose
+  - source activate test-environment
+  # coveralls not in conda repos :-(
+  - pip install coveralls
+
+install:
+  - conda build --python "$TRAVIS_PYTHON_VERSION" conda-recipe
+  - conda install slycot --use-local
+
+# TODO: replace with nose?
+script:
+  - python runtests.py --coverage
+
 after_success:
   - coveralls

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -2,11 +2,6 @@ package:
   name: slycot
   version: "0.2.0"
 
-#source:
-#  fn: slycot-0.1.1.tar.gz
-#  url: https://pypi.python.org/packages/source/s/slycot/slycot-0.1.1.tar.gz
-#  md5: 125aac075d539d36004cc3baf3626bc7
-
 build:
   number: 1
 
@@ -30,10 +25,6 @@ test:
     - slycot
 
 about:
-  home: https://pypi.python.org/pypi/slycot
-  license:  BSD License
+  home: https://github.com/python-control/slycot
+  license:  GPLv2
   summary: 'A wrapper for the SLICOT control and systems library'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/slycot/tests/test.py
+++ b/slycot/tests/test.py
@@ -12,7 +12,7 @@ class Test(unittest.TestCase):
         synthesis.sb02mt(1,1,1,1)
 
     def test_2(self):
-        from scipy import matrix
+        from numpy import matrix
         a = matrix("-2 0.5;-1.6 -5")
         Ar, Vr, Yr, VALRr, VALDr = math.mb05md(a, 0.1)
 


### PR DESCRIPTION
Build with "conda build" instead of setup.py

Conda only supports Python 2.7, and 3.3 and up, so drop 2.6 and 3.2, and
add 3.4 and 3.5.

Install gfortran for compiling, and nose for tests.

Don't install scipy; get matrix class from numpy instead.  Scipy is
still needed for one example for generalized eigenvalues.

Use the python-control channel for lapack.

Correct license in meta.yaml; the intended license of Slycot seems to GPLv2 (see
gpl-2.0.txt in root).

Change meta.yaml project URL to python-control Slycot project page.

Split out the build script from meta.yaml; this might make life slightly
easier for anyone attempting to build this on Windows.

Removed from meta.yaml some comments that look like they were inherited
from a cookie-cutter template.