### PR TITLE
Fix: a and c matrices must have at least one column in td04ad_r

### DIFF
--- a/slycot/src/transform.pyf
+++ b/slycot/src/transform.pyf
@@ -1,3 +1,6 @@
+!    -*- f90 -*-
+! Note: the context of this file is case sensitive.
+
 subroutine tb01id(job,n,m,p,maxred,a,lda,b,ldb,c,ldc,scale,info) ! in TB01ID.f
     character intent(in) :: job = 'A'
     integer required,check(n>0) :: n
@@ -227,11 +230,11 @@ subroutine td04ad_r(rowcol,m,p,index_bn,dcoeff,lddcoe,ucoeff,lduco1,lduco2,nr,a,
     integer intent(hide),depend(ucoeff) :: lduco1=shape(ucoeff,0)
     integer intent(hide),depend(ucoeff) :: lduco2=shape(ucoeff,1)
     integer intent(in,out) :: nr !=sum(index_bn)
-    double precision intent(out),dimension(max(1,nr),nr),depend(nr) :: a
+    double precision intent(out),dimension(max(1,nr),max(1,nr)),depend(nr) :: a
     integer intent(hide),depend(a) :: lda = shape(a,0) 
     double precision intent(out),dimension(max(1,nr),max(m,p)),depend(nr,m,p) :: b
     integer intent(hide),depend(b) :: ldb = shape(b,0)
-    double precision intent(out),dimension(max(1,max(m,p)),nr),depend(nr,m,p) :: c
+    double precision intent(out),dimension(max(1,max(m,p)),max(1,nr)),depend(nr,m,p) :: c
     integer intent(hide),depend(c) :: ldc = shape(c,0)
     double precision intent(out),dimension(max(1,p),m),depend(p,m) :: d
     integer intent(hide),depend(d) :: ldd = shape(d,0)

--- a/slycot/tests/test.py
+++ b/slycot/tests/test.py
@@ -1,7 +1,7 @@
 import unittest
-from .. import synthesis
-from .. import math
-
+from slycot import synthesis
+from slycot import math
+from slycot import transform
 
 class Test(unittest.TestCase):
 
@@ -48,3 +48,25 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(Ac[0][1], -1)
         self.assertAlmostEqual(Ac[1][0], 1)
         self.assertAlmostEqual(Ac[1][1], -3)
+
+    def test_td04ad_static(self):
+        """Regression: td04ad (TFM -> SS transformation) for static TFM"""
+        import numpy as np
+        from itertools import product
+        # 'C' fails on static TFs
+        for nout,nin,rc in product(range(1,6),range(1,6),['R']):
+            num = np.reshape(np.arange(nout*nin),(nout,nin,1))
+            if rc == 'R':
+                den = np.reshape(np.arange(1,1+nout),(nout,1))
+            else:
+                den = np.reshape(np.arange(1,1+nin),(nin,1))
+            index = np.tile([0],den.shape[0])
+            nr,a,b,c,d = transform.td04ad(rc,nin,nout,index,den,num)
+
+
+def suite():
+   return unittest.TestLoader().loadTestsFromTestCase(TestConvert)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Related to https://github.com/python-control/python-control/pull/129#issuecomment-271170675

Previously the a and c matrices submitted to SLICOT's `TD04AD` via Slycot's `td04ad_r` could have zero columns if the submitted transfer functions were constant.  This is reasonable, but f2py (or possibly other numpy component) objected. The fix is to ensure a minimum of 1 column; this doesn't affect the result, since `TD04AD` returns the number of required states, and only the required parts of the a, b, and c matrices are returned.

Unfortunately a similar fix does *not* work for `td04ad_c`; I believe this is due to a bug in SLICOT.  I'll file a separate issue for that.

This does not address the case when there are either no inputs (`m=0`) or outputs (`p=0`); I suspect a similar failure would occur in that case.