### PR TITLE
Fixes and workarounds for Conda build

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,2 +1,20 @@
+#!/bin/bash
 cd $RECIPE_DIR/..
-LDFLAGS="-shared" FFLAGS="-fPIC" $PYTHON setup.py install
+
+# conda's activate-gcc_linux-64.sh sets LDFLAGS to have the directory
+# entries for finding libpython, liblapack, etc., so we can't
+# overwrite it
+export LDFLAGS="-shared $LDFLAGS"
+
+# conda's activate-gfortran_linux-64.sh sets F95, but
+# numpy.distutils.fcompiler looks for F90
+# this is hopefully a temporary hack
+if [ ! -v F90 ]; then
+    if [ ! -v F95 ]; then
+        echo "build.sh:error: neither F90 nor F95 variable set"
+        exit 1
+    fi
+    export F90="$F95"
+fi
+
+$PYTHON setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -6,19 +6,16 @@ build:
   number: 1
 
 requirements:
-  build:
+  host:
     - python
     - numpy
-    - lapack
-    - m2w64-gcc-fortran # [win]
-    - gfortran_linux-64	# [linux]
-    - gfortran_osx-64	# [osx]
+    - {{ compiler('fortran') }}
+    - openblas
 
   run:
     - python
     - numpy
-    - lapack
-    - libgfortran
+    - libopenblas
 
 test:
   imports:


### PR DESCRIPTION
Still in progress, but I have successfully built on Travis with Conda with Python 2.7, 3.5, and 3.6.  The CI build fails with Python 3.6 in the non-Conda build; I'm still investigating that.  See https://travis-ci.org/roryyorke/Slycot/builds/391434012

The main changes:
  - openblas instead of lapack (openblas supplies liblapack and libblas)
  - add -shared to LDFLAGS instead of overwriting it
  - use new meta.yaml layout (not sure if this is critical)

To-do; would appreciate any assistance with these:
  - test on OSX (I can't do this)
  - test on Windows, in particular check I haven't broken @repagh's work on Windows builds
  - investigate test failure