### PR TITLE
Update slycot to version 0.3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,24 @@
 Slycot
-=============
+======
+
+.. image:: https://img.shields.io/pypi/v/slycot.svg
+   :target: https://pypi.org/project/slycot/
+
+.. image:: https://anaconda.org/conda-forge/slycot/badges/version.svg
+   :target: https://anaconda.org/conda-forge/slycot
 
 .. image:: https://travis-ci.org/python-control/slycot.svg?branch=master
-        :target: https://travis-ci.org/python-control/slycot
+   :target: https://travis-ci.org/python-control/slycot
+
 .. image:: https://coveralls.io/repos/python-control/slycot/badge.png
-        :target: https://coveralls.io/r/python-control/slycot
+   :target: https://coveralls.io/r/python-control/slycot
 
 Python wrapper for selected SLICOT routines, notably including solvers for
 Riccati, Lyapunov, and Sylvester equations.
 
 
-Prerequisites:
---------------
+Dependencies
+------------
 
 Slycot depends on Numpy and, if you are installing a binary distribution,
 Numpy should be the only prerequisite (though you may need the LAPACK
@@ -23,13 +30,13 @@ compiler, such as gfortran, and BLAS/LAPACK libraries.
 On Debian derivatives you should be able to install all the above with a
 single command::
 
-        sudo apt-get build-dep python-scipy
+    sudo apt-get build-dep python-scipy
 
 On Mac, you will first need to install the `developer tools
 <https://developer.apple.com/xcode/>`_.  You can then install gfortran using
 `homebrew <http://brew.sh>`_ with::
 
-        brew install gcc
+    brew install gcc
 
 On Windows, we suggest installing on top of the Python(x,y) distribution, and
 grabbing BLAS and LAPACK libraries from: 
@@ -39,64 +46,65 @@ http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.4.1/Dynamic-MI
 * install dll files in C:\Python27\DLLs
 * install lib files in C:\Python27\libs
 
-
 Installing
 -----------
 
 Using pip
 ~~~~~~~~~
 
-Slycot supports the pip packaging system. You must first have
-pip installed.
+Slycot supports the pip packaging system. You must first have pip installed.
 
-On debian linux based systems you can install pip with the command::
+On Debian Linux based systems you can install pip with the command::
 
-        sudo apt-get install pip
+    sudo apt-get install pip
 
-Pip can then be used to install Slycot wih the command::
+Pip can then be used to install Slycot with the command::
 
-        sudo pip install slycot
+    pip install slycot
 
-There are some binary "wheels" available on PyPI, so if those versions match
-with your system, you may be able to avoid installing from source.
+Note that installing with pip may or may not require having the build
+dependencies installed.  There are some binary "wheels" available on PyPI,
+so if those versions match with your system, you may be able to avoid
+installing from source.
 
 Using conda
 ~~~~~~~~~~~
 
-If you use `Anaconda or conda <http://continuum.io/downloads>`_ on Linux or Mac,
-it should be straighforward to install Slycot, without needing any compilers or
-other prerequisites.  Slycot is not included in the standard conda package
-repository, but there are packages available on conda-forge for Linux and
-Mac.  You can install with the following command::
+Slycot can be installed for Linux or Mac via the conda package manager from
+the conda-forge channel with the following command::
 
-  conda install -c conda-forge slycot
+    conda install -c conda-forge slycot
 
-
-From Source
+From source
 ~~~~~~~~~~~
 
-Unpack to a directory of your choice, say /path/to/slycot_src/, and execute::
+Unpack the course code to a directory of your choice,
+e.g. ``/path/to/slycot_src/``, and execute::
 
-        cd /path/to/slycot_src/
-        # python setup.py install
+    cd /path/to/slycot_src/
+    python setup.py install
 
 Where # is for commands that needs to be executed as root/administrator. 
 
 If the build fails and you are on a 64bit OS you may want to try::
 
-        cd /path/to/slycot_src/
-        python setup.py config_fc --arch="-march=x86-64" build
-        # python setup.py install
+    python setup.py config_fc --arch="-march=x86-64" build
+    python setup.py install
+
+You can also use conda to build and install slycot from source::
+
+    conda build conda-recipe
+	conda install --use-local slycot
 
 For Windows, and using Python(x,y), specify that you are using the
-mingw compiler. Create a file
+mingw compiler.  Create a file
 
-C:\\Python27\\Lib\\distutils\\distutils.cfg
+    C:\\Python27\\Lib\\distutils\\distutils.cfg
 
-with as contents::
+with contents::
 
-        [build]
-        compiler=mingw32
+    [build]
+    compiler=mingw32
 
 Additional tips for how to install slycot from source can be found in the
 .travis.yml (commands used for Travis CI) and conda-recipe/ (conda
@@ -110,10 +118,3 @@ properly with Python.  If you are using conda, you can also get working
 Note that in some cases you may need to set the LIBRARY_PATH environment
 variable to pick up dependencies such as -lpythonN.m (where N.m is the
 version of python you are using).
-
-
-To-Do
-------
- 
-- write unit tests, already added test script, and simple test
-- add examples in the doc-strings

--- a/README.rst
+++ b/README.rst
@@ -38,13 +38,10 @@ On Mac, you will first need to install the `developer tools
 
     brew install gcc
 
-On Windows, we suggest installing on top of the Python(x,y) distribution, and
-grabbing BLAS and LAPACK libraries from: 
+On Windows, the BLAS and LAPACK libraries can be obtained from: 
 
 http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.4.1/Dynamic-MINGW/Win32/
 
-* install dll files in C:\Python27\DLLs
-* install lib files in C:\Python27\libs
 
 Installing
 -----------
@@ -70,8 +67,8 @@ installing from source.
 Using conda
 ~~~~~~~~~~~
 
-Slycot can be installed for Linux or Mac via the conda package manager from
-the conda-forge channel with the following command::
+Slycot can be installed via the conda package manager from the conda-forge
+channel with the following command::
 
     conda install -c conda-forge slycot
 
@@ -94,17 +91,10 @@ If the build fails and you are on a 64bit OS you may want to try::
 You can also use conda to build and install slycot from source::
 
     conda build conda-recipe
-	conda install --use-local slycot
+    conda install --use-local slycot
 
-For Windows, and using Python(x,y), specify that you are using the
-mingw compiler.  Create a file
-
-    C:\\Python27\\Lib\\distutils\\distutils.cfg
-
-with contents::
-
-    [build]
-    compiler=mingw32
+If you prefer to use the OpenBLAS library, a conda recipe is available in
+``conda-recipe-openblas``.
 
 Additional tips for how to install slycot from source can be found in the
 .travis.yml (commands used for Travis CI) and conda-recipe/ (conda
@@ -114,6 +104,8 @@ properly with Python.  If you are using conda, you can also get working
 (binary) copies of LAPACK from conda-forge using the command::
 
 	conda install -c conda-forge lapack
+
+Slycot will also work with the OpenBLAS libraries.
 
 Note that in some cases you may need to set the LIBRARY_PATH environment
 variable to pick up dependencies such as -lpythonN.m (where N.m is the

--- a/conda-recipe-openblas/meta.yaml
+++ b/conda-recipe-openblas/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: slycot
-  version: "0.3.2"
+  version: "0.3.3"
 
 build:
   number: 1

--- a/conda-recipe-openblas/meta.yaml
+++ b/conda-recipe-openblas/meta.yaml
@@ -3,7 +3,8 @@ package:
   version: "0.3.3"
 
 build:
-  number: 1
+  number: 0
+
 requirements:
   host:
     - numpy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.3.3"
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: slycot
-  version: "0.3.2"
+  version: "0.3.3"
 
 build:
   number: 1

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ Operating System :: MacOS
 
 MAJOR = 0
 MINOR = 3
-MICRO = 2
+MICRO = 3
 POST = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)

--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -37,6 +37,9 @@ else:
     from .transform import tf01md, tf01rd
     from .transform import td04ad, tb01pd
 
+    # Version information
+    from .version import version as __version__
+
     from numpy.testing import Tester
     test = Tester().test
     bench = Tester().bench


### PR DESCRIPTION
This PR updates `slycot` to version 0.3.3 in `setup.py` and the `meta.yaml` files in the conda recipes.  It also updates the README file to copy over changes from (now incompatible) PR #22 and sets up a new variable `slycot.__version__`.

Someone (@repagh? @roryyorke?) should do a quick check on this PR and then we can merge and release v0.3.3.

The changes in v0.3.3 over v0.3.2 are:

* Updated TD04AD (PR #27)
* Updated setup.py and conda recipes (PR #26)
