### PR TITLE
conda install --use-local slycot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
       conda config --append channels conda-forge;
       conda build --python "$TRAVIS_PYTHON_VERSION" conda-recipe;
       conda install -c conda-forge lapack;
-      conda install --override-channels -c local slycot;
+      conda install --use-local slycot;
     else
       LAPACKLIBS=lapack:blas python setup.py install;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ env:
   - TEST_CONDA=0
   - TEST_CONDA=1
 
+# Install display manager to allow testing of plotting functions
+# Install fortran compiler
+addons:
+  apt:
+    packages:
+      - xvfb
+      - gfortran
+
 before_install:
   #
   # Install fortran compiler, if not using Conda's


### PR DESCRIPTION
* This PR intends to repair #41 `conda install --override-channels -c local slycot` being [unable to find the local `slycot`](https://travis-ci.org/kangwonlee/Slycot/jobs/455874419#L822) for [`python 2.7 && TEST_CONDA=1`](https://travis-ci.org/kangwonlee/Slycot/jobs/455874419).
* After this change, the build could find the local `slycot`but [one](https://travis-ci.org/python-control/Slycot/jobs/464862675#L1278) or [two](https://travis-ci.org/python-control/Slycot/jobs/464885225#L1963) of tests still may fail.
* Please see if this makes the code more harmonious.
