### PR TITLE
Don't use deprecated np.matrix in tests.

### DIFF
--- a/slycot/tests/test.py
+++ b/slycot/tests/test.py
@@ -12,8 +12,8 @@ class Test(unittest.TestCase):
         synthesis.sb02mt(1,1,1,1)
 
     def test_2(self):
-        from numpy import matrix
-        a = matrix("-2 0.5;-1.6 -5")
+        from numpy import array
+        a = array([[-2, 0.5], [-1.6, -5]])
         Ar, Vr, Yr, VALRr, VALDr = math.mb05md(a, 0.1)
 
     def test_sb02ad(self):

--- a/slycot/tests/test_sg02ad.py
+++ b/slycot/tests/test_sg02ad.py
@@ -18,24 +18,24 @@ class test_sg03ad(unittest.TestCase):
         m = 1
         # from a discussion here:
         # https://github.com/scipy/scipy/issues/2251
-        A = np.matrix([[ 0.63399379,  0.54906824,  0.76253406],
+        A = np.array([[ 0.63399379,  0.54906824,  0.76253406],
             [ 0.5404729 ,  0.53745766,  0.08731853],
             [ 0.27524045,  0.84922129,  0.4681622 ]])
-        B = np.matrix([[ 0.96861695],[ 0.05532739],[ 0.78934047]])
-        Q = np.matrix(np.eye(3))
-        E = np.matrix(np.eye(3))
-        R = np.matrix(np.ones((1,1), dtype=float))
-        S = np.matrix([[-2.67522766, -5.39447418,  2.19128542],
-                        [-1.94918951, -3.15480639,  5.24379117],
-                        [ 4.29133973,  8.10585767, -5.88895897]])
-        L = np.matrix(np.zeros((3,1)))
+        B = np.array([[ 0.96861695],[ 0.05532739],[ 0.78934047]])
+        Q = np.eye(3)
+        E = np.eye(3)
+        R = np.ones((1,1), dtype=float)
+        S = np.array([[-2.67522766, -5.39447418,  2.19128542],
+                      [-1.94918951, -3.15480639,  5.24379117],
+                      [ 4.29133973,  8.10585767, -5.88895897]])
+        L = np.array(np.zeros((3,1)))
         rcondu, X, alphar, alphai, beta, S, T, U, iwarn = \
             synthesis.sg02ad('D', 'B', 'N', 'U', 'Z', 'N', 'S', 'R',
                              n, m, 1,
                              A, E, B, Q, R, L)
         assert_almost_equal(
-            A.T*X*A - E.T*X*E -
-            (L + A.T*X*B) * np.linalg.solve (R+B.T*X*B, (L+A.T*X*B).T) +
+            A.T.dot(X).dot(A) - E.T.dot(X).dot(E) -
+            (L + A.T.dot(X).dot(B)) .dot( np.linalg.solve (R+B.T.dot(X).dot(B), (L+A.T.dot(X).dot(B)).T) ) +
             Q,
             np.zeros((n,n)))
 

--- a/slycot/tests/test_sg03ad.py
+++ b/slycot/tests/test_sg03ad.py
@@ -21,12 +21,9 @@ class test_sg03ad(unittest.TestCase):
         Xref = np.ones((n,n)) 
         U = np.tril(Xref)
         for t in range(0, 50, 10):
-            A = np.matrix(
-                2.0**(-t) - np.eye(n) + np.diag(range(1,n+1)) + U.T)
-            #print(A)
-            #print(t, n)
-            E = np.matrix(np.eye(n) + 2**(-t)*U)
-            Y = A.T*Xref*E + E.T*Xref*A
+            A = 2.0**(-t) - np.eye(n) + np.diag(range(1,n+1)) + U.T
+            E = np.eye(n) + 2**(-t)*U
+            Y = A.T.dot(Xref).dot(E) + E.T.dot(Xref).dot(A)
             Q = np.zeros((n,n))
             Z = np.zeros((n,n))
             A, E, Q, Z, X, scale, sep, ferr, alphar, alphai, beta = \
@@ -35,20 +32,20 @@ class test_sg03ad(unittest.TestCase):
         
     def test_sg03ad_3(self):
         n = 3
-        A = np.matrix([[3.0, 1.0, 1.0],
+        A = np.array([[3.0, 1.0, 1.0],
                       [1.0, 3.0, 0.0],
                       [1.0, 0.0, 2.0]])
-        E = np.matrix([[1.0, 3.0, 0.0],
+        E = np.array([[1.0, 3.0, 0.0],
                        [3.0, 2.0, 1.0],
                        [1.0, 0.0, 1.0]])
-        Y = np.matrix([[64.0, 73.0, 28.0],
+        Y = np.array([[64.0, 73.0, 28.0],
                        [73.0, 70.0, 25.0],
                        [28.0, 25.0, 18.0]])
         Xref = np.array([[-2.0000, -1.0000, 0.0000],
                           [-1.0000, -3.0000, -1.0000],
                           [0.0000, -1.0000, -3.0000]])
-        Q = np.matrix(np.zeros((3,3)))
-        Z = np.matrix(np.zeros((3,3)))
+        Q = np.zeros((3,3))
+        Z = np.zeros((3,3))
         A, E, Q, Z, X, scale, sep, ferr, alphar, alphai, beta = \
             synthesis.sg03ad('C', 'B', 'N', 'N', 'L', n, A, E, Q, Z, -Y)
         #print(A, E, Q, Z, X, scale, sep)


### PR DESCRIPTION
This silences deprecation warnings when running tests with newer (1.15?) Numpy.  I've only tested it on my own machine (Ubuntu 18.04) with Python 3.6; I'll recheck with other versions when #38 is merged.

This PR also serves as a proof-of-concept of the sort of changes we'd need to make for python-control/python-control#233 (see commit message below for details).  Luckily we don't seem to use the ```.H``` or ```.I``` attributes anywhere.  I'm not so sure about ```.A```, which is more difficult to grep for since SS objects have a ```.A``` attribute.



commit message:
This involves

  1. changing np.matrix to np.array, or removing conversion from array
     to matrix, and in one case by-hand converting "string
     constructor".
  2. replacing np.matrix "*" with np.array ".dot"; since we're still
     supporting Python 2.7, can't use "@".