### PR TITLE
Remove support for Python versions 2.6, 3.2, 3.3, and 3.4.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ Riccati, Lyapunov, and Sylvester equations.
 Dependencies
 ------------
 
+Supported Python versions are 2.7, and 3.5 and later.
+
 Slycot depends on Numpy and, if you are installing a binary distribution,
 Numpy should be the only prerequisite (though you may need LAPACK
 libraries as well, depending on your particular system configuration).

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,8 @@ else:
 from skbuild import setup
 from skbuild.command.sdist import sdist
 
-# Fix a bug in python v3.4 installation
-if (sys.version_info[0:2] == (3, 4)):
-    import importlib.machinery
-
-if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
-    raise RuntimeError("Python version 2.6, 2.7 or >= 3.2 required.")
+if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[0:2] < (3, 5):
+    raise RuntimeError("Python version 2.7 or >= 3.5 required.")
 
 DOCLINES = __doc__.split("\n")
 


### PR DESCRIPTION
Fixes #59.
