### PR TITLE
Fix Python 2.7 install and .travis configuration file issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,22 @@ matrix:
   include:
     - name: "Python 2.7, TEST_CONDA=0"
       env: SLYCOT_PYTHON_VERSION=2.7 TEST_CONDA=0
-    - name: "Python 2.7, TEST_CONDA=1"      
+    - name: "Python 2.7, TEST_CONDA=1"
       env: SLYCOT_PYTHON_VERSION=2.7 TEST_CONDA=1
 
     - name: "Python 3.5, TEST_CONDA=0"
-      env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=0
-    - name: "Python 3.5, TEST_CONDA=1"      
-      env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=1
+      env: SLYCOT_PYTHON_VERSION=3.5 TEST_CONDA=0
+    - name: "Python 3.5, TEST_CONDA=1"
+      env: SLYCOT_PYTHON_VERSION=3.5 TEST_CONDA=1
 
     - name: "Python 3.6, TEST_CONDA=0"
-      env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=0
-    - name: "Python 3.6, TEST_CONDA=1"      
-      env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=1
+      env: SLYCOT_PYTHON_VERSION=3.6 TEST_CONDA=0
+    - name: "Python 3.6, TEST_CONDA=1"
+      env: SLYCOT_PYTHON_VERSION=3.6 TEST_CONDA=1
 
     - name: "Python 3.7, TEST_CONDA=0"
       env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=0
-    - name: "Python 3.7, TEST_CONDA=1"      
+    - name: "Python 3.7, TEST_CONDA=1"
       env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=1
 
 before_install:
@@ -54,7 +54,7 @@ install:
   # Set up a test environment for testing everything out
   - conda create -q -n test-environment python="$SLYCOT_PYTHON_VERSION" pip coverage nose numpy openblas
   - source activate test-environment
-  
+
   #
   # Make sure that fortran compiler can find conda libraries
   #
@@ -66,8 +66,8 @@ install:
       conda install -c conda-forge scikit-build >=0.8.0 ;
     fi
   #
-  # Install the slycot package (two ways, to improve robustness).  For the 
-  # conda version, need to install lapack from conda-forge (no way to specify 
+  # Install the slycot package (two ways, to improve robustness).  For the
+  # conda version, need to install lapack from conda-forge (no way to specify
   # this in the recipe).
   # add the conda-forge channel to the config, otherwise openblas or
   # lapack cannot be found in the check

--- a/setup.py
+++ b/setup.py
@@ -150,10 +150,19 @@ def get_version_info(srcdir=None):
                           (ISRELEASED and 'yes') or 'no')
     elif os.path.exists('setup.cfg'):
         # valid distribution
-        setupcfg = configparser.ConfigParser()
+        setupcfg = configparser.ConfigParser(allow_no_value=True)
         setupcfg.read('setup.cfg')
-        FULLVERSION = setupcfg['metadata'].get('version', 'Unknown')
-        GIT_REVISION = setupcfg['metadata'].get('gitrevision', '')
+
+        FULLVERSION = setupcfg.get(section='metadata', option='version')
+
+        if FULLVERSION is None:
+            FULLVERSION = "Unknown"
+
+        GIT_REVISION = setupcfg.get(section='metadata', option='gitrevision')
+
+        if GIT_REVISION is None:
+            GIT_REVISION = ""
+
         return FULLVERSION, GIT_REVISION
     else:
 


### PR DESCRIPTION
Fix for installing Slycot in a Python 2.7 environment - unupported ConfigParser functionality for python 2.7.

Error was :  

```
ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-TzgjyK/slycot/setup.py", line 279, in <module>
        setup_package()
      File "/tmp/pip-install-TzgjyK/slycot/setup.py", line 210, in setup_package
        VERSION, gitrevision = get_version_info(src_path)
      File "/tmp/pip-install-TzgjyK/slycot/setup.py", line 149, in get_version_info
        FULLVERSION = setupcfg['metadata'].get('version', 'Unknown')
    AttributeError: ConfigParser instance has no attribute '__getitem__'
    ----------------------------------------
```

the `.travis.yml` file contains a wrong python 3.5  and 3.6 configuration.