### PR TITLE
 Better handling of missing dependencies on install and README improvements.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,6 @@ Slycot
 Python wrapper for selected SLICOT routines, notably including solvers for
 Riccati, Lyapunov, and Sylvester equations.
 
-
 Dependencies
 ------------
 
@@ -36,19 +35,18 @@ On Debian derivatives you should be able to install OpenBLAS using::
     sudo apt-get install libopenblas-dev
 
 Additionally install cmake and install scikit-build with pip or conda.
-    
+
 On Mac, you will first need to install the `developer tools
 <https://developer.apple.com/xcode/>`_.  You can then install gfortran using
 `homebrew <http://brew.sh>`_ with::
 
     brew install gcc
 
-On Windows, the BLAS and LAPACK libraries can be obtained from: 
+On Windows, the BLAS and LAPACK libraries can be obtained from:
 
 http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.4.1/Dynamic-MINGW/Win32/
 
 Alternatively, use conda to install BLAS and LAPACK or OpenBLAS
-
 
 Installing
 -----------
@@ -88,7 +86,7 @@ e.g. ``/path/to/slycot_src/``, and execute::
     cd /path/to/slycot_src/
     python setup.py install
 
-Where # is for commands that needs to be executed as root/administrator. 
+Where # is for commands that needs to be executed as root/administrator.
 
 If you need to specify a specific compiler, set the environment
 variable FC before running the install::
@@ -120,7 +118,7 @@ incompatible with Python 2.7.
 If you are using conda, you can also get working
 (binary) copies of LAPACK from conda-forge using the command::
 
-	conda install -c conda-forge lapack
+   conda install -c conda-forge lapack
 
 Slycot will also work with the OpenBLAS libraries.
 

--- a/README.rst
+++ b/README.rst
@@ -19,77 +19,67 @@ Riccati, Lyapunov, and Sylvester equations.
 Dependencies
 ------------
 
-Supported Python versions are 2.7, and 3.5 and later.
+Slycot supports Python versions 2.7 and >=3.5.
 
-Slycot depends on Numpy and, if you are installing a binary distribution,
-Numpy should be the only prerequisite (though you may need LAPACK
-libraries as well, depending on your particular system configuration).
+To run the compiled Slycot package, the following must be installed as
+dependencies:
 
-If you are installing Slycot from source, you will need a FORTRAN
-compiler, such as gfortran, and BLAS/LAPACK libraries. Openblas is
-also supported. The build system uses skbuild (scikit-buildsystem >=
-0.8.1) and cmake.
+- Python 2.7, 3.5+
+- NumPy
 
-On Debian derivatives you should be able to install OpenBLAS using::
+If you are compiling and installing Slycot from source, you will need the
+following dependencies:
 
-    sudo apt-get install libopenblas-dev
+- Python 2.7, 3.5+
+- NumPy
+- scikit-build >=0.8.1
+- cmake
+- C compiler (e.g. gcc, MS Visual C++)
+- FORTRAN compiler (e.g. gfortran, ifort, flang)
+- BLAS/LAPACK (e.g. OpenBLAS, ATLAS, MKL)
 
-Additionally install cmake and install scikit-build with pip or conda.
-
-On Mac, you will first need to install the `developer tools
-<https://developer.apple.com/xcode/>`_.  You can then install gfortran using
-`homebrew <http://brew.sh>`_ with::
-
-    brew install gcc
-
-On Windows, the BLAS and LAPACK libraries can be obtained from:
-
-http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.4.1/Dynamic-MINGW/Win32/
-
-Alternatively, use conda to install BLAS and LAPACK or OpenBLAS
+There are a variety of ways to install these dependencies on different
+operating systems. See the individual packages' documentation for options.
 
 Installing
 -----------
 
+In general Slycot requires non-trivial compilation to install on a given
+system. The easiest way to get started using Slycot is by installing
+pre-compiled binaries. The Slycot team provides pre-compiled binaries via the
+conda package manager and conda forge package hosting channel for Linux, OSX,
+and Windows.
+
+Using conda
+~~~~~~~~~~~
+
+Install Miniconda or Anaconda and then Slycot can be installed via the conda
+package manager from the conda-forge channel with the following command::
+
+    conda install -c conda-forge slycot
+
 Using pip
 ~~~~~~~~~
 
-Slycot supports the pip packaging system. You must first have pip installed.
-
-On Debian Linux based systems you can install pip with the command::
-
-    sudo apt-get install pip
+Slycot can also be installed via the pip package manager. Install pip as per
+recommendations in pip's documentation. At a minimum, Python and pip must be
+installed. If a pre-complied binary (i.e. "wheel") is available it will be
+installed with no need for compilation. If not, pip will attempt to compile the
+package from source and thus the compilation dependencies will be required
+(scikit-build, gfortran, BLAS, etc.).
 
 Pip can then be used to install Slycot with the command::
 
     pip install slycot
 
-Note that installing with pip may or may not require having the build
-dependencies installed.  There are some binary "wheels" available on PyPI,
-so if those versions match with your system, you may be able to avoid
-installing from source.
-
-Using conda
-~~~~~~~~~~~
-
-Slycot can be installed via the conda package manager from the conda-forge
-channel with the following command::
-
-    conda install -c conda-forge slycot
-
 From source
 ~~~~~~~~~~~
 
 Unpack the course code to a directory of your choice,
-e.g. ``/path/to/slycot_src/``, and execute::
+e.g. ``/path/to/slycot_src/``
 
-    cd /path/to/slycot_src/
-    python setup.py install
-
-Where # is for commands that needs to be executed as root/administrator.
-
-If you need to specify a specific compiler, set the environment
-variable FC before running the install::
+If you need to specify a specific compiler, set the environment variable FC
+before running the install::
 
     # Linux/OSX:
     export FC=/path/to/my/fortran
@@ -97,7 +87,12 @@ variable FC before running the install::
     # Windows:
     set FC=D:\path\to\my\fortran.exe
 
-You can also use conda to build and install slycot from source::
+To build and install execute::
+
+    cd /path/to/slycot_src/
+    python setup.py install
+
+You can also use conda to build and install Slycot from source::
 
     conda build conda-recipe
     conda install --use-local slycot
@@ -105,23 +100,22 @@ You can also use conda to build and install slycot from source::
 If you prefer to use the OpenBLAS library, a conda recipe is available in
 ``conda-recipe-openblas``.
 
-Additional tips for how to install slycot from source can be found in the
-.travis.yml (commands used for Travis CI) and conda-recipe/ (conda
-pre-requisities).
+Additional tips for how to install Slycot from source can be found in the
+``.travis.yml`` (commands used for Travis CI) and conda-recipe/ (conda
+pre-requisites) both which are included in the source code repository.
 
-The hardest part about installing from source is getting
-a working version of FORTRAN and LAPACK installed on your system and working
-properly with Python. On Windows, the build system currently uses
-flang, which can be installed from conda-forge. Note that flang is
-incompatible with Python 2.7.
+The hardest part about installing from source is getting a working version of
+FORTRAN and LAPACK installed on your system and working properly with Python.
+On Windows, the build system currently uses flang, which can be installed from
+conda-forge. Note that flang is incompatible with Python 2.7.
 
-If you are using conda, you can also get working
-(binary) copies of LAPACK from conda-forge using the command::
+If you are using conda, you can also get working (binary) copies of LAPACK from
+conda-forge using the command::
 
    conda install -c conda-forge lapack
 
 Slycot will also work with the OpenBLAS libraries.
 
-Note that in some cases you may need to set the LIBRARY_PATH environment
-variable to pick up dependencies such as -lpythonN.m (where N.m is the
+Note that in some cases you may need to set the ``LIBRARY_PATH`` environment
+variable to pick up dependencies such as ``-lpythonN.m`` (where N.m is the
 version of python you are using).

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,11 @@ if sys.version_info[0] >= 3:
 else:
     import __builtin__ as builtins
 
-from skbuild import setup
-from skbuild.command.sdist import sdist
+try:
+    from skbuild import setup
+    from skbuild.command.sdist import sdist
+except ImportError:
+    raise ImportError('sckit-build must be installed before running setup.py')
 
 if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[0:2] < (3, 5):
     raise RuntimeError("Python version 2.7 or >= 3.5 required.")
@@ -240,6 +243,7 @@ def setup_package():
                     '-DISRELEASE:STRING=' + str(ISRELEASED),
                     '-DFULL_VERSION=' + VERSION + '.git' + gitrevision[:7]],
         zip_safe=False,
+        install_requires=['numpy'],
     )
 
     # Windows builds use Flang.

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,15 @@ if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[0:2] < (3, 5):
 DOCLINES = __doc__.split("\n")
 
 CLASSIFIERS = """\
-Development Status :: 3 - Alpha
+Development Status :: 4 - Beta
 Intended Audience :: Science/Research
 Intended Audience :: Developers
 License :: OSI Approved
+License :: OSI Approved :: GNU General Public License v2 (GPLv2)
 Programming Language :: C
+Programming Language :: Fortran
 Programming Language :: Python
+Programming Language :: Python :: 2
 Programming Language :: Python :: 3
 Topic :: Software Development
 Topic :: Scientific/Engineering


### PR DESCRIPTION
- Raise an ImportError with informative message if scikit-build is not
  installed prior to executing setup.py.
- Include numpy in the install_requires of the setup function so that it
  will be installed if not present.
- Updated trove classifiers.
- Simplified and added clarity to the README.