### PR TITLE
Add packages entry to setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,7 @@ def setup_package():
 
     metadata = dict(
         name='slycot',
+        packages=['slycot', 'slycot.tests'],
         cmake_languages=('C', 'Fortran'),
         version=VERSION,
         maintainer="Slycot developers",


### PR DESCRIPTION
Without this entry, pip install fails to add the package to the Python path.