### PR TITLE
Build fixes: query numpy path directly; setup pyproject.toml for pip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 # base site dir, use python installation for location specific includes
 execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c
-  "from distutils.sysconfig import get_python_lib as pl; print(pl())"
+  "import os,numpy; print(os.path.dirname(numpy.__path__[0]))"
   OUTPUT_VARIABLE PYTHON_SITE
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(WIN32)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include README.rst
 include MANIFEST.in
 include setup.cfg.in
 include CMakeLists.txt
+include pyproject.toml
 include slycot/CMakeLists.txt
 include slycot/tests/CMakeLists.txt
 include slycot/*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ class sdist_checked(sdist):
 
 
 def setup_package():
-    src_path = os.path.dirname(os.path.abspath(sys.argv[0]))
+    src_path = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, src_path)
 
     # Rewrite the version file everytime


### PR DESCRIPTION
This is intended to fix #3, #63, and #65.  It works on Ubuntu 18.04, I'll still try to test it on Windows 10.  I don't have an iOS (MacOS? OSX? ... ) machine to test on.

The test is to prepare a source tarball with `python setup.py sdist` -- this needs numpy and scikit-build.  Then, in a fresh environment *without* those packages, or anything other than `pip`, run `pip install slycot.0.3.blah.tar.gz` (substitute version number for blah).  `pip install .` might be the same thing, I'm not sure.