### PR TITLE
fix CMakeLists.txt to find numpy and f2py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,5 +46,15 @@ if(WIN32)
   string(REPLACE "\\" "/" PYTHON_SITE ${PYTHON_SITE})
 endif()
 
+# base site dir, use python installation for location specific includes
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c
+  "from distutils.sysconfig import get_python_lib as pl; print(pl(plat_specific=True))"
+  OUTPUT_VARIABLE PYTHON_SITEARCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(WIN32)
+  string(REPLACE "\\" "/" PYTHON_SITEARCH ${PYTHON_SITEARCH})
+endif()
+
 add_subdirectory(slycot)
 

--- a/slycot/CMakeLists.txt
+++ b/slycot/CMakeLists.txt
@@ -128,7 +128,7 @@ add_custom_command(
 add_library(
   ${SLYCOT_MODULE} SHARED
   SLYCOTmodule.c _wrappermodule.c _wrapper-f2pywrappers.f
-  "${PYTHON_SITE}/numpy/f2py/src/fortranobject.c"
+  "${PYTHON_SITEARCH}/numpy/f2py/src/fortranobject.c"
   ${FSOURCES})
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
@@ -161,8 +161,8 @@ endif()
 
 target_include_directories(
   ${SLYCOT_MODULE} PUBLIC
-  ${PYTHON_SITE}/numpy/core/include
-  ${PYTHON_SITE}/numpy/f2py/src
+  ${PYTHON_SITEARCH}/numpy/core/include
+  ${PYTHON_SITEARCH}/numpy/f2py/src
   ${PYTHON_INCLUDE_DIRS}
   )
 


### PR DESCRIPTION
Some distributions install architecture specific python packages into directory structures like /usr/lib64/ instead of /usr/lib/. This patch allows CMake to find numpy and f2py in these directories.

CMake probably provides more sophisticated routines to find the correct python packages, but this patch is the closest to the existing routine I could come up with.