### PR TITLE
CI: put all OSX builds in allow_failure category

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ matrix:
       os: osx
       env: SLYCOT_PYTHON_VERSION=2.7 TEST_CONDA=1
 
+    - name: "OSX, Python 3.5, TEST_CONDA=1"
+      os: osx
+      env: SLYCOT_PYTHON_VERSION=3.5 TEST_CONDA=1
+
+    - name: "OSX, Python 3.6, TEST_CONDA=1"
+      os: osx
+      env: SLYCOT_PYTHON_VERSION=3.6 TEST_CONDA=1
+
+    - name: "OSX, Python 3.7, TEST_CONDA=1"
+      os: osx
+      env: SLYCOT_PYTHON_VERSION=3.7 TEST_CONDA=1
+
   include:
     - name: "OSX, Python 2.7, TEST_CONDA=1"
       os: osx


### PR DESCRIPTION
The OSX builds are all failing due to environment or build setup, not
Slycot-specific code.  Allow them to fail until we can find a fix.