### PR TITLE
remove shebang in source files without main execution path

### DIFF
--- a/slycot/analysis.py
+++ b/slycot/analysis.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 #       analysis.py
 #

--- a/slycot/examples.py
+++ b/slycot/examples.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 #       examples.py
 #       

--- a/slycot/math.py
+++ b/slycot/math.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 #       math.py
 #

--- a/slycot/synthesis.py
+++ b/slycot/synthesis.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 #       synthesis.py
 #

--- a/slycot/transform.py
+++ b/slycot/transform.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 #       transform.py
 #


### PR DESCRIPTION
These source files do nothing when executing from command line.

The shebang is unnecessary and produces [rpmlint warnings when packaging](https://build.opensuse.org/package/show/home:bnavigator:branches:devel:languages:python:numeric/python-slycot#rpm).