### PR TITLE
Fix lapack linker path + slycot directory case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,7 @@ script:
   # Local unit tests
   # TODO: replace with nose?
   - cd ..
-  - python Slycot/runtests.py --coverage --no-build
+  - python slycot/runtests.py --coverage --no-build
   #
   # As a deeper set of tests, get test against python-control as well
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,7 @@ script:
   # Local unit tests
   # TODO: replace with nose?
   - cd ..
-  - python slycot/runtests.py --coverage --no-build
+  - python Slycot/runtests.py --coverage --no-build
   #
   # As a deeper set of tests, get test against python-control as well
   #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ enable_language(Fortran)
 
 find_package(PythonLibs REQUIRED)
 find_package(NumPy REQUIRED)
-#set(BLA_VENDOR "OpenBLAS")
+set(BLA_VENDOR "OpenBLAS")
 find_package(LAPACK REQUIRED)
 message(STATUS "LAPACK: ${LAPACK_LIBRARIES}")
 message(STATUS "Slycot version: ${SLYCOT_VERSION}")


### PR DESCRIPTION
The `python-control` package has been having build problems and I traced these back to `slycot`.  The problem traced down to the `CMake` installation not correctly linking in the `lapack` library, which resulted in the following error during the build process for `slycot`:
```
python -c "import slycot"; fi
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/miniconda/envs/test-environment/lib/python3.7/site-packages/slycot-0.3.5.8-py3.7-linux-x86_64.egg/slycot/__init__.py", line 16, in <module>
    from .analysis import ab01nd,ab05md,ab05nd,ab07nd,ab08nd, \
  File "/home/travis/miniconda/envs/test-environment/lib/python3.7/site-packages/slycot-0.3.5.8-py3.7-linux-x86_64.egg/slycot/analysis.py", line 20, in <module>
    from . import _wrapper
ImportError: /home/travis/miniconda/envs/test-environment/lib/python3.7/site-packages/slycot-0.3.5.8-py3.7-linux-x86_64.egg/slycot/_wrapper.so: undefined symbol: dgebal_
```

In chasing this down, I found out that `CMake` was not setting the variable `LAPACK_LIBRARIES` in the `CMakeLists.txt` file.  Specifically, the following code
```
find_package(PythonLibs REQUIRED)
find_package(NumPy REQUIRED)
# set(BLA_VENDOR "OpenBLAS")
find_package(LAPACK REQUIRED)
message(STATUS "LAPACK: ${LAPACK_LIBRARIES}")
message(STATUS "Slycot version: ${SLYCOT_VERSION}")
```
generate the output
```
-- A library with LAPACK API found.
-- LAPACK: 
-- Slycot version: 0.3.5.8
```

It appears that the blank `LAPACK_LIBRARIES` variable meant  that `slycot` was not actually being linked against `lapack`.  To fix this, I removed the commented out line `set(BLA_VENDOR "OpenBLAS")`, which changes the output (on linux) to read:
```
-- A library with LAPACK API found.
-- LAPACK: /home/travis/miniconda/envs/test-environment/lib/libopenblas.so;/home/travis/miniconda/envs/test-environment/lib/libopenblas.so
```

This PR uncomments that line and fixes the problem.  I am not quite sure what changed that made this problem crop up...

@repagh Do you know/remember why that line was commented out.
