### PR TITLE
Tell cmake to find the openblas module in CONDA=0 travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ install:
       conda install conda-forge::openblas>=0.3.0;
       conda install local::slycot;
     else
-      CMAKE_GENERATOR="Unix Makefiles" python setup.py install;
+      CMAKE_GENERATOR="Unix Makefiles" python setup.py install -- -DBLA_VENDOR=OpenBLAS;
     fi
   #
   # coveralls not in conda repos :-(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ enable_language(Fortran)
 find_package(PythonLibs REQUIRED)
 find_package(NumPy REQUIRED)
 #set(BLA_VENDOR "OpenBLAS")
-find_package(LAPACK REQUIRED)
+find_package(LAPACK MODULE REQUIRED)
 message(STATUS "LAPACK: ${LAPACK_LIBRARIES}")
 message(STATUS "Slycot version: ${SLYCOT_VERSION}")
 


### PR DESCRIPTION
Alternative to #85. This tells cmake in the Travi-CI to find the OpenBLAS module which is installed from conda during those jobs:
https://github.com/python-control/Slycot/blob/2f31897759d2f7fa9909fecdefc73abfa5a5917e/.travis.yml#L127

In contrast to #85 this does not force non OpenBLAS users to modify their CMakeLists.txt