### PR TITLE
switch the additional python-control unittests to pytest in Travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,12 @@
 [run]
 source = slycot
-omit = */tests/*
+omit = 
+  */tests/*
+  */version.py
+
+
+# please do not add any sections after this block
+# the CI will add the slycot modules as last line here
+[paths]
+source =
+  slycot/

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,16 +138,24 @@ install:
 
 script:
   # slycots own unit tests as installed, not those from source dir
-  - cd ..
+  - mkdir ../slycot-coverage
+  - cd ../slycot-coverage
   - slycot_dir=$(python -c "import slycot; print(slycot.__path__[0])")
-  - pytest --pyargs slycot --cov=$slycot_dir --cov-config=Slycot/.coveragerc
+  - pytest --pyargs slycot --cov=$slycot_dir --cov-config=../Slycot/.coveragerc
   #
-  # As a deeper set of tests, get test against python-control as well
-  #
-  # Get python-control from source and install
-  - git clone --depth 1 https://github.com/python-control/python-control.git control
-  - cd control
-  - python setup.py test
+  # As a deeper set of tests, use the suite from python-control master branch as well
+  - cd ..
+  - git clone --depth 1 https://github.com/python-control/python-control.git
+  - cd python-control
+  - pytest --disable-warnings --cov=$slycot_dir --cov-config=../Slycot/.coveragerc control/tests
+
 
 after_success:
+  # go back to Slycot dir and merge the coverage to report correct repo data with coveralls
+  - cd ../Slycot
+  - cp ../slycot-coverage/.coverage .coverage.slycot
+  - cp ../python-control/.coverage .coverage.control
+  - echo "  $slycot_dir" >> .coveragerc
+  - coverage combine
+  - coverage report
   - coveralls


### PR DESCRIPTION
python-control switched its unit test runs to pytest. Let's do that in Slycot's CI run as well.

I could not test out how this affects coveralls. Depending on the outcome 7a1d846 might need to be reverted.