### PR TITLE
run examples in testsuite

### DIFF
--- a/slycot/tests/CMakeLists.txt
+++ b/slycot/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PYSOURCE
   test.py
   test_ab08n.py
   test_ag08bd.py
+  test_examples.py
   test_mb.py
   test_mc.py
   test_sb10jd.py

--- a/slycot/tests/test_examples.py
+++ b/slycot/tests/test_examples.py
@@ -1,0 +1,29 @@
+"""
+
+test_examples.py
+
+
+"""
+
+from inspect import getmembers, isfunction
+import pytest
+
+from slycot import examples
+
+examplefunctions = [fun for (fname, fun) in getmembers(examples)
+                    if isfunction(fun) and "_example" in fname]
+
+
+@pytest.mark.parametrize('examplefun', examplefunctions)
+def test_example(examplefun, capsys, recwarn):
+    """
+    Test the examples.
+
+    Test that all the examples work, produce some (unchecked) output but no
+    exceptions or warnings.
+    """
+    examplefun()
+    captured = capsys.readouterr()
+    assert len(captured.out) > 0
+    assert not captured.err
+    assert not recwarn


### PR DESCRIPTION
This PR introduces a test file to make sure that all the provided examples work.

As some examples use functions which are not tested in a unit test, this should increase coverage.

Due to precision differences on different machines, we cannot check the printed output for expected values without more complicated parsing. But at least the examples should not throw warnings or raise exceptions.