### PR TITLE
Fix unit tests option 2: run pytest with --pyargs slycot by default

### DIFF
--- a/setup.cfg.in
+++ b/setup.cfg.in
@@ -4,3 +4,7 @@ name = slycot
 version = @version@
 gitrevision = @gitrevision@
 release = @release@
+
+[tool:pytest]
+# run the tests with compiled and installed package
+addopts = --pyargs slycot


### PR DESCRIPTION
Option 2 as discussed in https://github.com/python-control/Slycot/issues/98#issuecomment-619635645

Make sure `pytest` tests with the installed module found in `sys.path`, not the local source dir without the compiled wrapper.