### PR TITLE
change test matrix for test_mb05md_warning

### DIFF
--- a/slycot/tests/test_mb.py
+++ b/slycot/tests/test_mb.py
@@ -268,12 +268,9 @@ class test_mb(unittest.TestCase):
     # TODO: move this to pytest recwarn together with the whole class
     @unittest.skipIf(sys.version < "3", "no assertWarns in old Python")
     def test_mb05md_warning(self):
-        """ Check that the correct warning is raised from docstring"""
-        A = np.array([[5, 4, 2, 1],
-                      [0, 1, -1, -1],
-                      [-1, -1, 3, 0],
-                      [1, 1, -1, 2]])
-        delta = 0.
+        """Check that the correct warning is raised from docstring"""
+        A = np.diag([3., 3., 3., 3.]) + np.diag([1., 1., 1.], k=1)
+        delta = 0.1
 
         with self.assertWarns(SlycotResultWarning,
                               msg="\n"


### PR DESCRIPTION
The originally chosen defective Matrix is not always detected, e.g. on ~[i586](https://build.opensuse.org/package/live_build_log/home:bnavigator/python-slycot-git/openSUSE_Tumbleweed/i586)~ (Edit: most recent log not appilcable anymore):

```
[  247s] =================================== FAILURES ===================================
[  247s] _________________________ test_mb.test_mb05md_warning __________________________
[  247s] 
[  247s] self = <slycot.tests.test_mb.test_mb testMethod=test_mb05md_warning>
[  247s] 
[  247s]     @unittest.skipIf(sys.version < "3", "no assertWarns in old Python")
[  247s]     def test_mb05md_warning(self):
[  247s]         """ Check that the correct warning is raised from docstring"""
[  247s]         A = np.array([[5, 4, 2, 1],
[  247s]                       [0, 1, -1, -1],
[  247s]                       [-1, -1, 3, 0],
[  247s]                       [1, 1, -1, 2]])
[  247s]         delta = 0.
[  247s]     
[  247s]         with self.assertWarns(SlycotResultWarning,
[  247s]                               msg="\n"
[  247s]                                   "Matrix A is defective, possibly "
[  247s]                                   "due to rounding errors.") as cm:
[  247s] >           (Ar, Vr, Yr, VAL) = mb05md(A, delta)
[  247s] E           AssertionError: SlycotResultWarning not triggered : 
[  247s] E           Matrix A is defective, possibly due to rounding errors.
```

Replacing by Jordan blocks, which succeed on all architectures.