### PR TITLE
[WIP] override XERBLA to raise exception

### DIFF
--- a/slycot/CMakeLists.txt
+++ b/slycot/CMakeLists.txt
@@ -104,7 +104,7 @@ set(FSOURCES
     src/delctg.f  src/select.f
     src/SLCT_DLATZM.f  src/SLCT_ZLATZM.f
 
-    src/ftruefalse.f
+    src/ftruefalse.f src/XERBLA.f
 )
 
 set(F2PYSOURCE src/_wrapper.pyf)

--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -43,6 +43,11 @@ else:
     # Version information
     from .version import version as __version__
 
+    # initialize error handling
+    from .exceptions import raise_xerbla
+    from . import _wrapper
+    _wrapper.raise_xerbla = raise_xerbla
+
     from numpy.testing import Tester
     test = Tester().test
     bench = Tester().bench

--- a/slycot/exceptions.py
+++ b/slycot/exceptions.py
@@ -257,3 +257,11 @@ def raise_if_slycot_error(info, arg_list=None, docstring=None, checkvars=None):
         warn(SlycotWarning("Caught unhandled nonzero IWARN value {}"
                            "".format(iwarn),
                            iwarn, info))
+
+
+def raise_xerbla(srname, info):
+    """Overrides LAPACK XERBLA routine to raise Exception instead of exiting
+    """
+    message = ("The argument number {1} to {0} had an illegal value."
+               "".format(srname, -info))
+    raise SlycotParameterError(message, info)

--- a/slycot/src/XERBLA.f
+++ b/slycot/src/XERBLA.f
@@ -1,0 +1,19 @@
+      SUBROUTINE XERBLA(SRNAME, INFO)
+C
+C     SLYCOT
+C     Override LAPACK XERBLA routine to raise Python Exception instead of
+C     exiting the process
+C
+CF2PY INTENT(CALLBACK, HIDE) RAISE_XERBLA
+C
+      CHARACTER*(*) SRNAME
+      INTEGER INFO
+C
+      EXTERNAL RAISE_XERBLA
+C
+      CALL RAISE_XERBLA(SRNAME, INFO)
+C
+      RETURN
+C
+      END
+C

--- a/slycot/src/_helper.pyf
+++ b/slycot/src/_helper.pyf
@@ -6,5 +6,10 @@ subroutine ftruefalse(ftrue,ffalse) ! in src/ftruefalse.f
     logical intent(out) :: ffalse
 end subroutine ftruefalse
 
-! This file was auto-generated with f2py (version:2).
-! See http://cens.ioc.ee/projects/f2py2e/
+subroutine xerbla(srname,info) ! in src/XERBLA.f
+    use __user__routines
+    character*(*) :: srname
+    integer :: info
+    intent(callback) raise_xerbla
+    external raise_xerbla
+end subroutine xerbla

--- a/slycot/src/_wrapper.pyf
+++ b/slycot/src/_wrapper.pyf
@@ -1,12 +1,23 @@
 !    -*- f90 -*-
 ! Note: the context of this file is case sensitive.
 
-python module _wrapper ! in
-    interface  ! in :wrapper
-		include "analysis.pyf"
-		include "math.pyf"
-		include "synthesis.pyf"
-		include "transform.pyf"
-		include "_helper.pyf"
+python module __user__routines
+    interface
+        subroutine raise_xerbla(srname,info)
+            intent(callback,hide) raise_xerbla
+            character*(*) :: srname
+            integer :: info
+        end subroutine raise_xerbla
+    end interface
+end python module __user__routines
+
+python module _wrapper
+    interface
+        include "analysis.pyf"
+        include "math.pyf"
+        include "synthesis.pyf"
+        include "transform.pyf"
+        include "_helper.pyf"
     end interface
 end python module slycot
+


### PR DESCRIPTION
Fixes #126 (eventually)

Trying to wrap the Fortran `XERBLA` call. Still having some issues with the parameter list.

```
Python 3.8.2 (default, Apr  8 2020, 14:31:25) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import slycot
>>> print(slycot._wrapper.xerbla.__doc__)
xerbla(srname,info,raise_xerbla,[raise_xerbla_extra_args])

Wrapper for ``xerbla``.

Parameters
----------
srname : input string(len=-1)
info : input int
raise_xerbla : call-back function

Other Parameters
----------------
raise_xerbla_extra_args : input tuple, optional
    Default: ()

Notes
-----
Call-back functions::

  def raise_xerbla(srname,info): return 
  Required arguments:
    srname : input string(len=-1)
    info : input int

>>> def raise_xerbla_2_arguments(srname, info):
...     raise Exception("If I was called with ({}, {}) you would see this".format(srname, info))
... 
>>> slycot._wrapper.raise_xerbla = raise_xerbla_2_arguments
>>> slycot.sb10fd(1,1,1,0,1,1,[1],[1],[1],[1],1e-3,1)
capi_return is NULL
Call-back cb_raise_xerbla_in___user__routines failed.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ben/src/Slycot/_skbuild/linux-x86_64-3.8/cmake-install/slycot/synthesis.py", line 2714, in sb10fd
    out = _wrapper.sb10fd(n, m, np, ncon, nmeas, gamma,
TypeError: raise_xerbla_2_arguments() missing 2 required positional arguments: 'srname' and 'info'

```

But:
```
Python 3.8.2 (default, Apr  8 2020, 14:31:25) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import slycot
>>> def raise_no_arguments():
...     raise Exception("no arguments provided")
... 
>>> slycot._wrapper.raise_xerbla = raise_no_arguments
>>> slycot.sb10fd(1,1,1,0,1,1,[1],[1],[1],[1],1e-3,1)
capi_return is NULL
Call-back cb_raise_xerbla_in___user__routines failed.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ben/src/Slycot/_skbuild/linux-x86_64-3.8/cmake-install/slycot/synthesis.py", line 2714, in sb10fd
    out = _wrapper.sb10fd(n, m, np, ncon, nmeas, gamma,
  File "<stdin>", line 2, in raise_no_arguments
Exception: no arguments provided
>>> 
```

