### PR TITLE
Override XERBLA to do nothing

### DIFF
--- a/slycot/CMakeLists.txt
+++ b/slycot/CMakeLists.txt
@@ -104,7 +104,7 @@ set(FSOURCES
     src/delctg.f  src/select.f
     src/SLCT_DLATZM.f  src/SLCT_ZLATZM.f
 
-    src/ftruefalse.f
+    src/ftruefalse.f src/XERBLA.f
 )
 
 set(F2PYSOURCE src/_wrapper.pyf)
@@ -139,7 +139,7 @@ add_custom_command(
 
 add_library(
   ${SLYCOT_MODULE} MODULE
-  _wrappermodule.c 
+  _wrappermodule.c
   ${PYTHON_SITE}/numpy/f2py/src/fortranobject.c
   _wrapper-f2pywrappers.f
   ${FSOURCES})

--- a/slycot/src/XERBLA.f
+++ b/slycot/src/XERBLA.f
@@ -1,0 +1,13 @@
+      SUBROUTINE XERBLA(SRNAME, INFO)
+C
+C     SLYCOT
+C     Override LAPACK XERBLA routine to noop instead
+C     of PRINT and STOP
+C
+      CHARACTER*(*) SRNAME
+      INTEGER INFO
+C
+      RETURN
+C
+      END
+C

--- a/slycot/src/_helper.pyf
+++ b/slycot/src/_helper.pyf
@@ -6,5 +6,7 @@ subroutine ftruefalse(ftrue,ffalse) ! in src/ftruefalse.f
     logical intent(out) :: ffalse
 end subroutine ftruefalse
 
-! This file was auto-generated with f2py (version:2).
-! See http://cens.ioc.ee/projects/f2py2e/
+subroutine xerbla(srname, info) ! in src/XERBLA.f
+    character*(*) :: srname
+    integer :: info
+end subroutine

--- a/slycot/tests/test_exceptions.py
+++ b/slycot/tests/test_exceptions.py
@@ -19,6 +19,8 @@ MA 02110-1301, USA.
 """
 
 import pytest
+import subprocess
+import sys
 
 from slycot.exceptions import raise_if_slycot_error, \
                               SlycotError, SlycotWarning, SlycotParameterError
@@ -88,3 +90,19 @@ def test_unhandled_info_iwarn():
     assert wm[1].message.info == 0
 
 
+# Test code for test_xerbla_override
+CODE = """
+from slycot._wrapper import ab08nd
+# equil='X' is invalid
+out = ab08nd(1, 1, 1, [1], [1], [1], [1], equil='X')
+print("INFO={}".format(out[-1]))
+"""
+
+
+def test_xerbla_override():
+    """Test that Fortran routines calling XERBLA do not print to stdout."""
+
+    stdout = subprocess.check_output([sys.executable, '-c', CODE],
+                                     stderr=subprocess.STDOUT,
+                                     text=True)
+    assert stdout == "INFO=-1\n"

--- a/slycot/tests/test_exceptions.py
+++ b/slycot/tests/test_exceptions.py
@@ -104,5 +104,5 @@ def test_xerbla_override():
 
     stdout = subprocess.check_output([sys.executable, '-c', CODE],
                                      stderr=subprocess.STDOUT,
-                                     text=True)
+                                     universal_newlines=True)
     assert stdout == "INFO=-1\n"


### PR DESCRIPTION
Fixes #126 and https://github.com/python-control/Slycot/issues/98#issuecomment-629742640

Other than in #127, the overriding subroutine simply does nothing and allows the Fortran call stack to return.

Even more than before, all Slycot wrappers have the obligation to check the `INFO` return value and provide a meaningful error message for 'INFO<0'. Calling `raise_if_slycot_error()` should take care of that.
