### PR TITLE
expand test_xerbla_override to allow debugging

### DIFF
--- a/slycot/tests/test_exceptions.py
+++ b/slycot/tests/test_exceptions.py
@@ -93,6 +93,8 @@ def test_unhandled_info_iwarn():
 
 # Test code for test_xerbla_override
 CODE = """
+import sys
+sys.path.pop(0)  # do not import from current directory ('')
 from slycot._wrapper import __file__, ab08nd
 print(__file__)
 # equil='X' is invalid

--- a/slycot/tests/test_exceptions.py
+++ b/slycot/tests/test_exceptions.py
@@ -104,17 +104,18 @@ print("INFO={}".format(out[-1]))
 def test_xerbla_override():
     """Test that Fortran routines calling XERBLA do not print to stdout."""
 
-    ret = subprocess.run([sys.executable, '-c', CODE],
-                         capture_output=True,
-                         universal_newlines=True)
-    if ret.returncode:
+    try:
+        out = subprocess.check_output([sys.executable, '-c', CODE],
+                                       stderr=subprocess.STDOUT,
+                                       universal_newlines=True)
+    except subprocess.CalledProcessError as cpe:
         raise RuntimeError("Trying to call _wrapper.ab08nd() failed with "
                            "returncode {}.\n"
                            "Captured STDOUT: \n {}\n"
                            "Captured STDERR: \n {}\n"
-                           "".format(ret.returncode, ret.stdout, ret.stderr))
+                           "".format(cpe.returncode, cpe.stdout, cpe.stderr))
 
-    outlines = ret.stdout.splitlines()
+    outlines = out.splitlines()
     assert len(outlines) == 2
     assert outlines[0] == _wrapper.__file__
     assert outlines[1] == "INFO=-1"


### PR DESCRIPTION
Be more verbose if the test fails. It could fail because of xerbla not being overridden or because the import of the wrapper library failed.