### PR TITLE
Add a pytest header module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ you'll have to choose the right recipe directory.
 On Linux you can choose between ``conda-recipe-openblas`` and
 ``conda-recipe-mkl``
 
-On macOS you should use ``conda-recipe-apple``. See the 
+On macOS you should use ``conda-recipe-apple``. See the
 `conda-build documentation`_ how to get the required macOS SDK.
 
 .. _conda-build documentation: https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html#macos-sdk
@@ -129,9 +129,16 @@ install Slycot (this example creates a Python 3.8 environment)::
     conda activate build-slycot
 
     python setup.py install
-    pytest
 
-The final ``pytest`` command is optional; it runs the Slycot unit tests.
+Testing
+~~~~~~~
+To test if the installation was successful, you can run the slycot unit tests::
+
+    pytest --pyargs slycot
+
+Running ``pytest`` without ``--pyargs slycot`` from inside the source directory
+will fail, unless either ``setup.cfg`` or the compiled wrapper library have
+been installed into that directory.
 
 General notes on compiling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -248,6 +248,8 @@ def setup_package():
                     '-DFULL_VERSION=' + VERSION + '.git' + gitrevision[:7]],
         zip_safe=False,
         install_requires=['numpy'],
+        entry_points={"pytest11":
+                      ["slycot_pytest_header=slycot.tests.slycot_pytest_header"]}
     )
 
     # Windows builds use Flang.

--- a/slycot/CMakeLists.txt
+++ b/slycot/CMakeLists.txt
@@ -117,7 +117,7 @@ configure_file(version.py.in version.py @ONLY)
 
 set(PYSOURCE
 
-  __init__.py analysis.py examples.py math.py synthesis.py
+  __init__.py analysis.py examples.py exceptions.py math.py synthesis.py
   transform.py ${CMAKE_CURRENT_BINARY_DIR}/version.py)
 
 set(SLYCOT_MODULE "_wrapper")

--- a/slycot/tests/CMakeLists.txt
+++ b/slycot/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(PYSOURCE
 
   __init__.py
   test_ab01.py
+  slycot_pytest_header.py
   test_ab08n.py
   test_ag08bd.py
   test_examples.py

--- a/slycot/tests/slycot_pytest_header.py
+++ b/slycot/tests/slycot_pytest_header.py
@@ -1,0 +1,14 @@
+"""
+slycot_pytest_header.py
+
+pytest module to display slycot information in the test report header
+"""
+
+from slycot import __version__, __path__, _wrapper
+
+
+def pytest_report_header(config):
+    """Add slycot environment info to pytest report header"""
+    return ['Slycot version: {}'.format(__version__),
+            'Slycot path: {}'.format(__path__),
+            'Slycot wrapper library: {}'.format(_wrapper.__file__)]


### PR DESCRIPTION
In order to determine fast wether the correct package and wrapper library are tested, display them in the pytest header.

Needs to be installed into the distribtution as as pytest module via setuptools, because we usually run pytest from outside of the source dir.