### PR TITLE
switch old numpy nosetester to pytest call

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,9 +136,16 @@ To test if the installation was successful, you can run the slycot unit tests::
 
     pytest --pyargs slycot
 
-Running ``pytest`` without ``--pyargs slycot`` from inside the source directory
-will fail, unless either ``setup.cfg`` or the compiled wrapper library have
-been installed into that directory.
+You may also run the tests by calling ``slycot.test()`` from within the python
+interpreter::
+
+    import slycot
+    slycot.test()
+
+Importing ``slycot`` or running ``pytest`` without ``--pyargs slycot`` from
+inside the source directory will fail, unless the compiled wrapper library has
+been installed into that directory. Note that the ``[tool:pytest]`` section
+in ``setup.cfg`` enforces the ``--pyargs slycot`` argument by default.
 
 General notes on compiling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -6,7 +6,7 @@ except NameError:
 
 if __SLYCOT_SETUP__:
     import sys as _sys
-    _sys.stderr.write('Running from numpy source directory.\n')
+    _sys.stderr.write('Running from Slycot source directory.\n')
     del _sys
 else:
 

--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -43,6 +43,7 @@ else:
     # Version information
     from .version import version as __version__
 
-    from numpy.testing import Tester
-    test = Tester().test
-    bench = Tester().bench
+
+def test():
+    import pytest
+    pytest.main(['--pyargs', 'slycot'])


### PR DESCRIPTION
Fixes #134 

Numpy did something similar in https://github.com/numpy/numpy/pull/10827

I guess those lines for `.test` and `.bench` in Slycot came from and old documentation for writing numpy modules. Slycot currently does not have any benchmarks and according to the numpy PR, `bench` is not used anymore.