### PR TITLE
BUG: correct mb03rd for default X=None argument

### DIFF
--- a/slycot/math.py
+++ b/slycot/math.py
@@ -42,7 +42,7 @@ def mb03rd(n, A, X=None, jobx='U', sort='N', pmax=1.0, tol=0.0):
             The matrix `A` to be block-diagonalized, in real Schur form.
         X : (n, n) array_like, optional
             A given matrix `X`, for accumulation of transformations (only if
-            `jobx`='U')
+            `jobx`='U').   Default value is identity matrix of order `n`.
         jobx : {'N', 'U'}, optional
             Specifies whether or not the transformations are
             accumulated, as follows:
@@ -230,7 +230,7 @@ def mb03rd(n, A, X=None, jobx='U', sort='N', pmax=1.0, tol=0.0):
                 'dwork' + hidden, 'info']
 
     if X is None:
-        X = np.zeros((1, n))
+        X = np.eye(n)
 
     Ar, Xr, nblcks, blsize, wr, wi, info = _wrapper.mb03rd(
         jobx, sort, n, pmax, A, X, tol)

--- a/slycot/math.py
+++ b/slycot/math.py
@@ -42,7 +42,7 @@ def mb03rd(n, A, X=None, jobx='U', sort='N', pmax=1.0, tol=0.0):
             The matrix `A` to be block-diagonalized, in real Schur form.
         X : (n, n) array_like, optional
             A given matrix `X`, for accumulation of transformations (only if
-            `jobx`='U').   Default value is identity matrix of order `n`.
+            `jobx`='U'). Default value is identity matrix of order `n`.
         jobx : {'N', 'U'}, optional
             Specifies whether or not the transformations are
             accumulated, as follows:

--- a/slycot/tests/test_mb.py
+++ b/slycot/tests/test_mb.py
@@ -86,7 +86,6 @@ class test_mb(unittest.TestCase):
                     test1_n, A, X, 'N', sort, test1_pmax, test1_tol)
             assert Xr is None
 
-
     def test_mb03rd_default(self):
         # regression: mb03rd was failing with no third arg (X) supplied
         A = np.array([[ 6, -1, -7, -2,  2],
@@ -105,7 +104,6 @@ class test_mb(unittest.TestCase):
 
         assert_allclose(Ar, Ar2)
         assert_allclose(Xr, Tschur.dot(Xr2))
-
 
     def test_mb03vd_mb03vy_ex(self):
         """Test MB03VD and MB03VY

--- a/slycot/tests/test_mb.py
+++ b/slycot/tests/test_mb.py
@@ -86,6 +86,27 @@ class test_mb(unittest.TestCase):
                     test1_n, A, X, 'N', sort, test1_pmax, test1_tol)
             assert Xr is None
 
+
+    def test_mb03rd_default(self):
+        # regression: mb03rd was failing with no third arg (X) supplied
+        A = np.array([[ 6, -1, -7, -2,  2],
+                      [-3,  4,  2, -7,  6],
+                      [-6, -9, -3, -1, 10],
+                      [-2, -4,  1,  5,  7],
+                      [-7, -5, -6,  6,  7]])
+
+        Aschur, Tschur = schur(A)
+
+        X = Tschur.copy()
+
+        Ar, Xr, blsize, W = mb03rd(Aschur.shape[0], Aschur, X, 'U', 'N', pmax=1.0, tol=0.0)
+
+        Ar2, Xr2, blsize2, W2 = mb03rd(Aschur.shape[0], Aschur)
+
+        assert_allclose(Ar, Ar2)
+        assert_allclose(Xr, Tschur.dot(Xr2))
+
+
     def test_mb03vd_mb03vy_ex(self):
         """Test MB03VD and MB03VY
            with the example given in the MB03VD SLICOT documentation"""


### PR DESCRIPTION
Added a test for this case.

@repagh I think this is a reasonably simple fix -- do you have time to review it?
