### PR TITLE
fix conda install of built package in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services: xvfb # needed for the python-control tests
 
 # Start with a 2x4 matrix of Linux builds
 python:
+ - "3.9
  - "3.8"
  - "3.7"
 env:
@@ -20,14 +21,6 @@ jobs:
     - name: "Linux, Conda Python 3.6"
       python: "3.6"
       env: TEST_PKG="conda" BLA_VENDOR="OpenBLAS"
-    - name: "Linux, Conda Python 3.5"
-      python: "3.5"
-      env: TEST_PKG="conda" BLA_VENDOR="OpenBLAS"
-    - name: "Linux, Ubuntu 16.04, System Python 2.7"
-      python: "2.7"
-      dist: xenial
-      env: TEST_PKG="dist" BLA_VENDOR="OpenBLAS"
-    # (Conda Python 2 is broken due to pytest-cov dependencies)
     - name: "MacOSX, Conda Python 3"
       os: osx
       language: shell
@@ -36,14 +29,10 @@ jobs:
       os: osx
       language: shell
       env: TEST_PKG="dist" BLA_VENDOR="Apple"
-    - name: "MacOSX, pyenv 3.8.0"
+    - name: "MacOSX, pyenv 3.8.7"
       os: osx
       language: shell
-      env: TEST_PKG="dist" BLA_VENDOR="Apple" SLYCOT_PYTHON_VERSION=3.8.0
-    - name: "MacOSX, pyenv 2.7.17"
-      os: osx
-      language: shell
-      env: TEST_PKG="dist" BLA_VENDOR="Apple" SLYCOT_PYTHON_VERSION=2.7.17
+      env: TEST_PKG="dist" BLA_VENDOR="Apple" SLYCOT_PYTHON_VERSION=3.8.7
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,8 @@ install:
             $conda_blas
       conda activate test-environment
       export LIBRARY_PATH="$HOME/miniconda/envs/test-environment/lib"
-      conda build --python "$SLYCOT_PYTHON_VERSION" $conda_recipe
+      numpyversion=$(python -c 'import numpy; print(numpy.version.version)')
+      conda build --python "$SLYCOT_PYTHON_VERSION" --numpy $numpyversion $conda_recipe
       conda install local::slycot
     elif [[ $TEST_PKG == dist ]]; then
       pip install scikit-build pytest-cov matplotlib scipy;


### PR DESCRIPTION
Fix  conda fails on Travis CI one last time (?) before we move to Github Actions.

See https://github.com/python-control/Slycot/pull/139#issuecomment-752524357. Sibling of https://github.com/scikit-build/scikit-build/issues/524, but here conda is the offender, not scikit-build.