### PR TITLE
Clean build setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,13 @@ jobs:
       os: osx
       language: shell
       env: TEST_PKG="dist" BLA_VENDOR="Apple"
-    - name: "MacOSX, pyenv 3.8.7"
+    - name: "MacOSX, pyenv 3.8.0"
       os: osx
       language: shell
-      env: TEST_PKG="dist" BLA_VENDOR="Apple" SLYCOT_PYTHON_VERSION=3.8.7
-
+      env: TEST_PKG="dist" BLA_VENDOR="Apple" SLYCOT_PYTHON_VERSION=3.8.0
+  allow_failures:
+    - python: "3.9"
+      env: TEST_PKG="conda" BLA_VENDOR="Intel10_64lp"
 
 before_install:
   - |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,46 +7,21 @@ if (CMAKE_VERSION VERSION_GREATER "3.11.99")
 endif()
 
 project(slycot VERSION ${SLYCOT_VERSION} LANGUAGES NONE)
-# Fortran detection fails on windows, use the CMAKE_C_SIMULATE flag to
-# force success
-if(WIN32)
-  set(CMAKE_Fortran_SIMULATE_VERSION 19.0)
-endif()
 
-# this does not seem to work, maybe scikit-build's doing? the cxx compiler is
-# still tested
 enable_language(C)
 enable_language(Fortran)
 
-# base site dir, use python installation for location specific includes
-execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c
-  "import os,numpy; print(os.path.dirname(numpy.__path__[0]))"
-  OUTPUT_VARIABLE PYTHON_SITE
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(WIN32)
-  string(REPLACE "\\" "/" PYTHON_SITE ${PYTHON_SITE})
-endif()
-
 find_package(PythonLibs REQUIRED)
+find_package(PythonExtensions REQUIRED)
 find_package(NumPy REQUIRED)
+find_package(F2PY REQUIRED)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
-message(STATUS "NumPy: ${NumPy_INCLUDE_DIR}")
+message(STATUS "NumPy included from: ${NumPy_INCLUDE_DIR}")
+message(STATUS "F2PY included from: ${F2PY_INCLUDE_DIR}")
 message(STATUS "LAPACK: ${LAPACK_LIBRARIES}")
 message(STATUS "BLAS: ${BLAS_LIBRARIES}")
 message(STATUS "Slycot version: ${SLYCOT_VERSION}")
 
-# find python, standard packages, F2PY find flaky on Windows
-if (NOT WIN32)
-  find_package(F2PY REQUIRED)
-endif()
-
-# pic option for flang not correct, remove for Windows
-if (WIN32)
-  set(CMAKE_Fortran_COMPILE_OPTIONS_PIC "")
-endif()
-
 add_subdirectory(slycot)
-

--- a/README.rst
+++ b/README.rst
@@ -19,18 +19,18 @@ Riccati, Lyapunov, and Sylvester equations.
 Dependencies
 ------------
 
-Slycot supports Python versions 2.7, and 3.5 or later.
+Slycot supports Python versions 3.6 or later.
 
 To run the compiled Slycot package, the following must be installed as
 dependencies:
 
-- Python 2.7, 3.5+
+- Python 3.6+
 - NumPy
 
 If you are compiling and installing Slycot from source, you will need the
 following dependencies:
 
-- Python 2.7, 3.5+
+- 3.6+
 - NumPy
 - scikit-build >= 0.10.0
 - CMake

--- a/slycot/CMakeLists.txt
+++ b/slycot/CMakeLists.txt
@@ -122,7 +122,6 @@ set(PYSOURCE
   ${CMAKE_CURRENT_BINARY_DIR}/version.py)
 
 set(SLYCOT_MODULE "_wrapper")
-find_package(PythonExtensions REQUIRED)
 
 set(GENERATED_MODULE
   ${CMAKE_CURRENT_BINARY_DIR}/${SLYCOT_MODULE}${PYTHON_EXTENSION_MODULE_SUFFIX})
@@ -141,7 +140,7 @@ add_custom_command(
 add_library(
   ${SLYCOT_MODULE} MODULE
   _wrappermodule.c
-  ${PYTHON_SITE}/numpy/f2py/src/fortranobject.c
+  ${F2PY_INCLUDE_DIR}/fortranobject.c
   _wrapper-f2pywrappers.f
   ${FSOURCES})
 
@@ -150,8 +149,7 @@ target_link_libraries(${SLYCOT_MODULE}
 
 target_include_directories(
   ${SLYCOT_MODULE} PUBLIC
-  ${PYTHON_SITE}/numpy/core/include
-  ${PYTHON_SITE}/numpy/f2py/src
+  ${F2PY_INCLUDE_DIRS}
   ${PYTHON_INCLUDE_DIRS}
   )
 


### PR DESCRIPTION
It turns out that some of the code in setup.py and the CMake files is no longer needed. Not even for Windows. (#140 is not ready yet, but it builds on this one and I already *had* successful Windows builds which also passed the unit tests.)

- Reverts a change in which I broke a MacOSX Travis run, because pyenv on Travis is too old.
- Ignores that the conda package built against mkl on Python 3.9 produces a crash. Compiling against specific LAPACK/BLAS packages is not the way to compile conda packages anymore. https://conda-forge.org/docs/maintainer/knowledge_base.html#blas
- Related: https://github.com/python-control/Slycot/pull/140#discussion_r550238923

