### PR TITLE
install conda-verify

### DIFF
--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -152,7 +152,7 @@ jobs:
         shell: bash -l {0}
         run: |
           set -e
-          conda install conda-build numpy
+          conda install conda-build conda-verify numpy
           numpyversion=$(python -c 'import numpy; print(numpy.version.version)')
           conda-build --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
           # preserve directory structure for custom conda channel


### PR DESCRIPTION
Windows builds hang for several minutes, and after the hang they report, that they could not find conda-verify.

Let's see if this helps.