### PR TITLE
python-control#537 needs pytest-timeout for rlocus test

### DIFF
--- a/.github/conda-env/test-env.yml
+++ b/.github/conda-env/test-env.yml
@@ -4,6 +4,8 @@ dependencies:
   - conda-build  # for conda index
   - scipy
   - matplotlib
+  - pytest
   - pytest-cov
+  - pytest-timeout
   - coverage
   - coveralls

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Install Wheel
         run: |
           python -m pip install --upgrade pip
-          pip install matplotlib scipy pytest pytest-cov coverage coveralls
+          pip install matplotlib scipy pytest pytest-cov pytest-timeout coverage coveralls
           pip install slycot-wheels/${{ matrix.packagekey }}/slycot*.whl
           pip show slycot
       - name: Slycot and python-control tests


### PR DESCRIPTION
Corresponding change for python-control/python-control#537