### PR TITLE
limit sniff-build to Python 3.9

### DIFF
--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -24,6 +24,8 @@ jobs:
           submodules: 'recursive'
       - name: Set up Python
         uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
       - name: Setup Ubuntu
         run: |
           sudo apt-get -y install gfortran cmake --fix-missing


### PR DESCRIPTION
GHA defaults to Python 3.10 already, but scipy did not yet publish a wheel for the cp310 ABI.

This forces the first check of our CI to build its own scipy wheel, which takes a long time.