### PR TITLE
sunset py 3.6, test 3.10

### DIFF
--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -55,10 +55,9 @@ jobs:
               - 'ubuntu'
               - 'macos'
             python:
-              - '3.6'
               - '3.7'
-              - '3.8'
               - '3.9'
+              - '3.10'
             bla_vendor: [ 'unset' ]
             include:
               - os: 'ubuntu'
@@ -143,8 +142,8 @@ jobs:
             - 'macos'
             - 'windows'
           python:
-            - '3.6'
             - '3.9'
+            - '3.10'
 
     steps:
       - name: Checkout Slycot

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -143,7 +143,6 @@ jobs:
             - 'windows'
           python:
             - '3.9'
-            - '3.10'
 
     steps:
       - name: Checkout Slycot

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - {{ compiler('fortran') }}  # [not win]
     - {{ compiler('c') }}
     - cmake
-    - flang  # [win]
+    - flang >=11  # [win]
 
   host:
     # Always build against NETLIB ('Generic') LAPACK/Blas

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ try:
 except ImportError:
     raise ImportError('scikit-build must be installed before running setup.py')
 
-if sys.version_info[0:2] < (3, 6):
-    raise RuntimeError("Python version >= 3.6 required.")
-
 DOCLINES = __doc__.split("\n")
 
 CLASSIFIERS = """\
@@ -37,10 +34,10 @@ License :: OSI Approved :: GNU General Public License v2 (GPLv2)
 Programming Language :: C
 Programming Language :: Fortran
 Programming Language :: Python
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Topic :: Software Development
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows
@@ -243,6 +240,7 @@ def setup_package():
                     '-DFULL_VERSION=' + VERSION + '.git' + gitrevision[:7]],
         zip_safe=False,
         install_requires=['numpy'],
+        python_requires=">=3.7"
     )
 
     try:


### PR DESCRIPTION
Python 3.6 has been removed from the NumPy support matrix quite some time ago ([NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)), Main Python 3.6 [reaches EOL](https://www.python.org/dev/peps/pep-0494/) next month. No reason to further torture the CI with it.

Meanwhile, SciPy wheels for Python 3.10 are available.

There are also no severe differences between Python 3.7 and 3.8. Testing the older one should be enough.