### PR TITLE
Enable Python 3.10 for conda testing

### DIFF
--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -143,6 +143,7 @@ jobs:
             - 'windows'
           python:
             - '3.9'
+            - '3.10'
 
     steps:
       - name: Checkout Slycot

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - {{ compiler('fortran') }}  # [not win]
     - {{ compiler('c') }}
     - cmake
+    - make  # [linux]
     - flang >=11  # [win]
 
   host:


### PR DESCRIPTION
Let's have this PR open until conda-forge is ready with Python 3.10 and it builds (or we figure out what has to be fixed)