### PR TITLE
Addition of Binder link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,13 @@
+Have a go now!
+======
+Try out the examples in the examples folder using the binder service.
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/python-control/python-control/HEAD
+
+
+
+
 Slycot
 ======
 


### PR DESCRIPTION
added binder link so people browsing can start up a binder of the library and immediately try out the examples

Minimal change with no impact on users other than permitting people coming across this library for the first time to try it quickly.
