### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/conda-env/build-env.yml
+++ b/.github/conda-env/build-env.yml
@@ -1,4 +1,6 @@
 name: build-env
 dependencies:
-  - boa
-  - numpy!=1.23.0
+  - conda-build
+  - conda-verify
+  # - boa # re-enable when boa is compatible with mamba 1.0 and Python 3.11
+  - numpy !=1.23.0

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           set -e
           numpyversion=$(python -c 'import numpy; print(numpy.version.version)')
-          conda mambabuild --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
+          conda build --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
           # preserve directory structure for custom conda channel
           find "${CONDA_PREFIX}/conda-bld" -maxdepth 2 -name 'slycot*.tar.bz2' | while read -r conda_pkg; do
             conda_platform=$(basename $(dirname "${conda_pkg}"))

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -144,7 +144,7 @@ jobs:
             - 'windows'
           python:
             - '3.9'
-            - '3.10'
+            - '3.11'
 
     steps:
       - name: Checkout Slycot

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -23,9 +23,9 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: '3.11'
       - name: Setup Ubuntu
         run: |
           sudo apt-get -y install gfortran cmake --fix-missing
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Setup Ubuntu
@@ -243,7 +243,7 @@ jobs:
           repository: 'python-control/python-control'
           path: python-control
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Setup Ubuntu

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
               echo "bla_vendor option ${{ matrix.bla_vendor }} not supported"
               exit 1 ;;
           esac
-          echo "FC=gfortran-10" >> $GITHUB_ENV
+          echo "FC=gfortran-11" >> $GITHUB_ENV
       - name: Build wheel
         env:
           BLA_VENDOR: ${{ matrix.bla_vendor }}

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Setup Ubuntu
         run: |
           sudo apt-get -y install gfortran cmake --fix-missing
@@ -58,23 +58,23 @@ jobs:
               - 'macos'
             python:
               - '3.7'
-              - '3.10'
+              - '3.11'
             bla_vendor: [ 'unset' ]
             include:
               - os: 'ubuntu'
-                python: '3.10'
+                python: '3.11'
                 bla_vendor: 'Generic'
               - os: 'ubuntu'
-                python: '3.10'
+                python: '3.11'
                 bla_vendor: 'OpenBLAS'
               - os: 'macos'
-                python: '3.10'
+                python: '3.11'
                 bla_vendor: 'Apple'
               - os: 'macos'
-                python: '3.10'
+                python: '3.11'
                 bla_vendor: 'Generic'
               - os: 'macos'
-                python: '3.10'
+                python: '3.11'
                 bla_vendor: 'OpenBLAS'
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -19,18 +19,18 @@ Riccati, Lyapunov, and Sylvester equations.
 Dependencies
 ------------
 
-Slycot supports Python versions 3.6 or later.
+Slycot supports Python versions 3.7 or later.
 
 To run the compiled Slycot package, the following must be installed as
 dependencies:
 
-- Python 3.6+
+- Python 3.7+
 - NumPy
 
 If you are compiling and installing Slycot from source, you will need the
 following dependencies:
 
-- 3.6+
+- Python 3.7+
 - NumPy
 - scikit-build
 - CMake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
Python 3.11.0 is out.

Bump a couple of version specifiers.

(Conda-forge is not ready yet.)