### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/conda-env/build-env.yml
+++ b/.github/conda-env/build-env.yml
@@ -1,6 +1,4 @@
 name: build-env
 dependencies:
-  - conda-build
-  - conda-verify
-  # - boa # re-enable when boa is compatible with mamba 1.0 and Python 3.11
-  - numpy !=1.23.0
+  - boa
+  - numpy!=1.23.0

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           set -e
           numpyversion=$(python -c 'import numpy; print(numpy.version.version)')
-          conda build --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
+          conda mambabuild --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
           # preserve directory structure for custom conda channel
           find "${CONDA_PREFIX}/conda-bld" -maxdepth 2 -name 'slycot*.tar.bz2' | while read -r conda_pkg; do
             conda_platform=$(basename $(dirname "${conda_pkg}"))

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -126,7 +126,7 @@ jobs:
           mkdir -p ${wheeldir}
           cp ./slycot*.whl ${wheeldir}/
       - name: Save wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -148,7 +148,7 @@ jobs:
 
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -176,7 +176,7 @@ jobs:
             cp "${conda_pkg}" "slycot-conda-pkgs/${conda_platform}/"
           done
       - name: Save to local conda pkg channel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
@@ -190,9 +190,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download wheels (if any)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -210,9 +210,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download conda packages
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
@@ -234,11 +234,11 @@ jobs:
 
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: slycot-src
       - name: Checkout python-control
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'python-control/python-control'
           path: python-control
@@ -276,7 +276,7 @@ jobs:
               exit 1 ;;
           esac
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -313,11 +313,11 @@ jobs:
 
     steps:
       - name: Checkout Slycot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: slycot-src
       - name: Checkout python-control
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'python-control/python-control'
           path: python-control
@@ -335,7 +335,7 @@ jobs:
           channel-priority: strict
           auto-activate-base: false
       - name: Download conda packages
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -197,9 +197,7 @@ jobs:
           name: slycot-wheels
           path: slycot-wheels
       - id: set-matrix
-        run: |
-          matrix=$(python3 .github/scripts/set-pip-test-matrix.py)
-          echo "::set-output name=matrix::$matrix"
+        run: echo "matrix=$(python3 .github/scripts/set-pip-test-matrix.py)" >> $GITHUB_OUTPUT
 
   create-conda-test-matrix:
     name: Create conda test matrix
@@ -217,9 +215,7 @@ jobs:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
       - id: set-matrix
-        run: |
-          matrix=$(python3 .github/scripts/set-conda-test-matrix.py)
-          echo "::set-output name=matrix::$matrix"
+        run: echo "matrix=$(python3 .github/scripts/set-conda-test-matrix.py)" >> $GITHUB_OUTPUT
 
 
   test-wheel:

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
               - 'ubuntu'
               - 'macos'
             python:
-              - '3.7'
+              - '3.8'
               - '3.11'
             bla_vendor: [ 'unset' ]
             include:

--- a/README.rst
+++ b/README.rst
@@ -19,18 +19,18 @@ Riccati, Lyapunov, and Sylvester equations.
 Dependencies
 ------------
 
-Slycot supports Python versions 3.7 or later.
+Slycot supports Python versions 3.8 or later.
 
 To run the compiled Slycot package, the following must be installed as
 dependencies:
 
-- Python 3.7+
+- Python 3.8+
 - NumPy
 
 If you are compiling and installing Slycot from source, you will need the
 following dependencies:
 
-- Python 3.7+
+- Python 3.8+
 - NumPy
 - scikit-build
 - CMake

--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ A similar method can be used for Linux and macOS, but is detailed here
 for Windows.  This method uses conda and conda-forge to get most build
 dependencies, *except* for the C compiler.
 
-This procedure has been tested on Python 3.7 and 3.8.
+This procedure has been tested on Python 3.8.
 
 1. Install `Microsoft Visual Studio`_.
 2. Unpack the source code to a directory of your choice,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Fortran",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -37,7 +36,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy",
 ]


### PR DESCRIPTION
- Conda-forge dropped support for Python 3.7. There are no py37 packages of today's released Slycot v0.5.1.
- NumPy 1.23 also dropped support according to NEP29.