### PR TITLE
Bump setuptools_scm to 7

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pip
     - scikit-build >=0.15
     - setuptools >=45
-    - setuptools_scm >=6.3
+    - setuptools_scm >=7
 
   run:
     - python {{ PY_VER }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=45",
-    "setuptools_scm>=6.3",
+    "setuptools_scm>=7",
     "wheel",
     "scikit-build>=0.15",
     "cmake>=3.14",


### PR DESCRIPTION
Noticed this while packaging for openSUSE: the `__version__` attribute used in our `__init__.py` is only added to the `version.py` for setuptools_scm >= 7.