### PR TITLE
update workflow to pass jobname to python-control pytest

### DIFF
--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -283,7 +283,7 @@ jobs:
           pip install slycot-wheels/${{ matrix.packagekey }}/slycot*.whl
           pip show slycot
       - name: Slycot and python-control tests
-        run: JOBNAME=$JOBNAME bash slycot-src/.github/scripts/run-tests.sh
+        run: JOBNAME="$JOBNAME" bash slycot-src/.github/scripts/run-tests.sh
         env:
           JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
       - name: report coverage
@@ -361,7 +361,7 @@ jobs:
           mamba install -c ./slycot-conda-pkgs slycot
           conda list
       - name: Slycot and python-control tests
-        run: JOBNAME=$JOBNAME bash slycot-src/.github/scripts/run-tests.sh
+        run: JOBNAME="$JOBNAME" bash slycot-src/.github/scripts/run-tests.sh
         env:
           JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
       - name: Report coverage

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -283,7 +283,9 @@ jobs:
           pip install slycot-wheels/${{ matrix.packagekey }}/slycot*.whl
           pip show slycot
       - name: Slycot and python-control tests
-        run: bash slycot-src/.github/scripts/run-tests.sh
+        run: JOBNAME=$JOBNAME bash slycot-src/.github/scripts/run-tests.sh
+        env:
+          JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
       - name: report coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -359,7 +361,9 @@ jobs:
           mamba install -c ./slycot-conda-pkgs slycot
           conda list
       - name: Slycot and python-control tests
-        run: bash slycot-src/.github/scripts/run-tests.sh
+        run: JOBNAME=$JOBNAME bash slycot-src/.github/scripts/run-tests.sh
+        env:
+          JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
       - name: Report coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -285,7 +285,7 @@ jobs:
       - name: Slycot and python-control tests
         run: JOBNAME="$JOBNAME" bash slycot-src/.github/scripts/run-tests.sh
         env:
-          JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
+          JOBNAME: wheel ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
       - name: report coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -363,7 +363,7 @@ jobs:
       - name: Slycot and python-control tests
         run: JOBNAME="$JOBNAME" bash slycot-src/.github/scripts/run-tests.sh
         env:
-          JOBNAME: ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
+          JOBNAME: conda ${{ matrix.packagekey }} ${{ matrix.blas_lib }}
       - name: Report coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR passes information about the current OS and BLAS version that is being used in slycot testing to python-control unit tests to avoid generating errors on known failure modes.  This allows the changes in [python-control PR #821](https://github.com/python-control/python-control/pull/821) to xfail on configurations that were causing errors (outside of slycot functionality).

A better fix would be to somehow set up the python-control unit tests to only run those that rely on slycot functions when using for slycot testing.  But I couldn't think of an easy way to do that.
