### PR TITLE
Don't include package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,10 @@ class sdist_checked(sdist):
 
 # These need to stay in setup.py
 # https://scikit-build.readthedocs.io/en/latest/usage.html#setuptools-options
-setup(     
+setup(
     packages=['slycot', 'slycot.tests'],
     cmdclass={'sdist': sdist_checked},
     cmake_languages=('C', 'Fortran'),
     use_scm_version = True,
+    include_package_data = False,
 )


### PR DESCRIPTION
Starting with scikit-build 0.17 all files included into the sdist through MANIFEST.in are also included into produced wheels.

See https://github.com/scikit-build/scikit-build/pull/873, https://github.com/scikit-build/scikit-build/issues/864

This is not desired for us, as it would install the whole source into the system or venv toplevel prefix:

<details>

```
Archive:  dist/slycot-0.5.4.dev6+g373cdc0-cp310-cp310-linux_x86_64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
    22431  2023-04-25 19:11   slycot/CMakeLists.txt
     1546  2023-04-25 19:11   slycot/__init__.py
  4715272  2023-04-25 19:11   slycot/_wrapper.cpython-310-x86_64-linux-gnu.so
    85946  2023-04-25 19:11   slycot/analysis.py
     9082  2023-04-25 19:11   slycot/examples.py
     8737  2023-04-25 19:11   slycot/exceptions.py
    30976  2023-04-25 19:11   slycot/math.py
   107860  2023-04-25 19:11   slycot/synthesis.py
    55443  2023-04-25 19:11   slycot/transform.py
      194  2023-04-25 19:11   slycot/version.py
      207  2023-04-25 19:11   slycot/src/XERBLA.f
      335  2023-04-25 19:11   slycot/src/_helper.pyf
      292  2023-04-25 19:11   slycot/src/_wrapper.pyf
    23086  2023-04-25 19:11   slycot/src/analysis.pyf
      252  2023-04-25 19:11   slycot/src/ftruefalse.f
     6368  2023-04-25 19:11   slycot/src/math.pyf
    46295  2023-04-25 19:11   slycot/src/synthesis.pyf
    28949  2023-04-25 19:11   slycot/src/transform.pyf
       58  2023-04-25 19:11   slycot/src/SLICOT-Reference/.git
     1862  2023-04-25 19:11   slycot/src/SLICOT-Reference/Contributors.md
     1514  2023-04-25 19:11   slycot/src/SLICOT-Reference/LICENSE
     3224  2023-04-25 19:11   slycot/src/SLICOT-Reference/README.md
    17990  2023-04-25 19:11   slycot/src/SLICOT-Reference/ReleaseNotes.md
    38876  2023-04-25 19:11   slycot/src/SLICOT-Reference/libindex.html
      492  2023-04-25 19:11   slycot/src/SLICOT-Reference/benchmark_data/BB01103.dat
...
      348  2023-04-25 19:11   slycot/src/SLICOT-Reference/src/readme
      186  2023-04-25 19:11   slycot/src/SLICOT-Reference/src/select.f
      359  2023-04-25 19:11   slycot/tests/CMakeLists.txt
        0  2023-04-25 19:11   slycot/tests/__init__.py
     1936  2023-04-25 19:11   slycot/tests/test_ab01.py
     3063  2023-04-25 19:11   slycot/tests/test_ab08n.py
     4107  2023-04-25 19:11   slycot/tests/test_ab13md.py
     4145  2023-04-25 19:11   slycot/tests/test_ag08bd.py
     2434  2023-04-25 19:11   slycot/tests/test_analysis.py
     1952  2023-04-25 19:11   slycot/tests/test_examples.py
     4390  2023-04-25 19:11   slycot/tests/test_exceptions.py
    14232  2023-04-25 19:11   slycot/tests/test_mb.py
     1575  2023-04-25 19:11   slycot/tests/test_mc.py
     8712  2023-04-25 19:11   slycot/tests/test_sb.py
     1531  2023-04-25 19:11   slycot/tests/test_sg02ad.py
     2591  2023-04-25 19:11   slycot/tests/test_sg03ad.py
     8898  2023-04-25 19:11   slycot/tests/test_tb05ad.py
     8707  2023-04-25 19:11   slycot/tests/test_td04ad.py
     2573  2023-04-25 19:11   slycot/tests/test_tg01ad.py
     4403  2023-04-25 19:11   slycot/tests/test_tg01fd.py
      914  2023-04-25 19:11   slycot/tests/test_transform.py
      328  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/AUTHORS
      758  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/CMakeLists.txt
      750  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/COPYING
     9065  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/README.rst
    18092  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/gpl-2.0.txt
     1622  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/pyproject.toml
      195  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/conda-recipe/bld.bat
      178  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/conda-recipe/build.sh
     1568  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.data/data/conda-recipe/meta.yaml
      328  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.dist-info/AUTHORS
      750  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.dist-info/COPYING
    10408  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.dist-info/METADATA
       99  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.dist-info/WHEEL
        7  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.dist-info/top_level.txt
   202251  2023-04-25 19:11   slycot-0.5.4.dev6+g373cdc0.dist-info/RECORD
---------                     -------
 23600291                     2015 files

```

</details>


Override the new default to `False`

