### PR TITLE
Check if likely-to-be-used Numpy include directory is from virtual env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,4 +22,18 @@ message(STATUS "F2PY headers included from: ${F2PY_INCLUDE_DIRS}")
 message(STATUS "LAPACK: ${LAPACK_LIBRARIES}")
 message(STATUS "BLAS: ${BLAS_LIBRARIES}")
 
+# https://github.com/python-control/Slycot/issues/193
+if((EXISTS "${Python_INCLUDE_DIRS}/numpy")
+    AND (NOT ("${Python_INCLUDE_DIRS}/numpy" EQUAL "${Python_NumPy_INCLUDE_DIRS}")))
+
+  message(FATAL_ERROR
+  "Python include directory has a numpy sub-directory,
+      ${Python_INCLUDE_DIRS}/numpy,
+  which is different from Numpy include directory
+    ${Python_NumPy_INCLUDE_DIRS}.
+  You're probably building in a virtual environment, in which case
+  uninstall numpy from the base environment and try again.")
+
+endif()
+
 add_subdirectory(slycot)


### PR DESCRIPTION
Addresses gh-193, in that the user gets an error.

This is a band-aid, not a solution, and I'm ok with us not merging it.