### PR TITLE
Refactor __init__.py

### DIFF
--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -14,16 +14,16 @@ else:
 
     # The Slycot library is organised by 11-chapters. Each chapter can be identified by a single letter.
     # The following chapters are included:
-    # A : Analysis Routines
+    # A : Analysis Routines (included)
     # B : Benchmark
     # C : Adaptive Control
     # D : Data Analysis
     # F : Filtering
     # I : Identification
-    # M : Mathematical Routines
+    # M : Mathematical Routines (included)
     # N : Nonlinear Systems
-    # S : Synthesis Routines
-    # T : Transformation Routines
+    # S : Synthesis Routines (included)
+    # T : Transformation Routines (included)
     # U : Utility Routines
 
 
@@ -46,9 +46,9 @@ else:
     # Identification routines (0/15 wrapped)
 
     # Mathematical routines (7/281 wrapped)
-    from .math import (mc01td, 
-                       mb03rd, mb03vd, mb03vy, mb03wd,
-                       mb05md, mb05nd)
+    from .math import (mb03rd, mb03vd, mb03vy, mb03wd,
+                       mb05md, mb05nd,
+                       mc01td)
 
     # Nonlinear Systems (0/16 wrapped)
 
@@ -61,7 +61,6 @@ else:
                             sg02ad,
                             sg03ad, sg03bd)
                             
-
     # Transformation routines (10/77 wrapped)
     from .transform import (tb01id, tb01pd,
                             tb03ad,

--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -12,23 +12,47 @@ else:
 
     # import slycot.examples
 
-    # Analysis routines (15/40 wrapped)
-    from .analysis import ab01nd, ab05md, ab05nd, ab07nd, ab08nd, ab08nz
-    from .analysis import ab09ad, ab09ax, ab09bd, ab09md, ab09nd
-    from .analysis import ab13bd, ab13dd, ab13ed, ab13fd, ab13md
+    # The Slycot library is organised by 11-chapters. Each chapter can be identified by a single letter.
+    # The following chapters are included:
+    # A : Analysis Routines
+    # B : Benchmark
+    # C : Adaptive Control
+    # D : Data Analysis
+    # F : Filtering
+    # I : Identification
+    # M : Mathematical Routines
+    # N : Nonlinear Systems
+    # S : Synthesis Routines
+    # T : Transformation Routines
+    # U : Utility Routines
 
 
-    # Data analysis routines (0/7 wrapped)
+    # Analysis routines (16/60 wrapped)
+    from .analysis import (ab01nd,
+                           ab05md, ab05nd,
+                           ab07nd,
+                           ab08nd, ab08nz,
+                           ab09ad, ab09ax, ab09bd, ab09md, ab09nd,
+                           ab13bd, ab13dd, ab13ed, ab13fd, ab13md)
+    
+    # Benchmark routines (0/6 wrapped)
+
+    # Adaptive control routines (0/0 wrapped)
+
+    # Data analysis routines (0/8 wrapped)
 
     # Filtering routines (0/6 wrapped)
 
-    # Identification routines (0/5 wrapped)
+    # Identification routines (0/15 wrapped)
 
-    # Mathematical routines (7/81 wrapped)
-    from .math import mc01td, mb03rd, mb03vd, mb03vy, mb03wd, mb05md, mb05nd
+    # Mathematical routines (7/281 wrapped)
+    from .math import (mc01td, 
+                       mb03rd, mb03vd, mb03vy, mb03wd,
+                       mb05md, mb05nd)
 
-    # Synthesis routines (15/50 wrapped)
+    # Nonlinear Systems (0/16 wrapped)
 
+    # Synthesis routines ((15+1)/131 wrapped), sb03md57 is not part of slicot
     from .synthesis import (sb01bd,
                             sb02md, sb02mt, sb02od, 
                             sb03md, sb03md57, sb03od,
@@ -38,12 +62,17 @@ else:
                             sg03ad, sg03bd)
                             
 
-    # Transformation routines (9/40 wrapped)
-    from .transform import tb01id, tb03ad, tb04ad
-    from .transform import tb05ad
-    from .transform import tc04ad, tc01od
-    from .transform import tf01md, tf01rd
-    from .transform import td04ad, tb01pd
+    # Transformation routines (10/77 wrapped)
+    from .transform import (tb01id, tb01pd,
+                            tb03ad,
+                            tb04ad,
+                            tb05ad,
+                            tc01od, tc04ad,
+                            td04ad,
+                            tf01md, tf01rd)
+
+    # Utility routines (0/7 wrapped)
+
 
     from .version import __version__
 


### PR DESCRIPTION
This PR refactors the `Slycot/slycot/__init__.py`.

- Adds comments describing the organization.
- Unifies the imports.
- Arranges the imports alphabetically.
- Updates the counts of slycot and slicot routines (slycot/slicot wrappers).

![slycot_wrapper_counts](https://github.com/python-control/Slycot/assets/25572221/3005e302-164c-4d81-ac34-58fcdb820cc9)
