### PR TITLE
Remove use_scm_version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=45",
-    "setuptools_scm>=7",
+    "setuptools_scm>=8",
     "wheel",
     "scikit-build>=0.15",
     "cmake>=3.14",

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,5 @@ setup(
     packages=['slycot', 'slycot.tests'],
     cmdclass={'sdist': sdist_checked},
     cmake_languages=('C', 'Fortran'),
-    use_scm_version = True,
     include_package_data = False,
 )


### PR DESCRIPTION
Fixes the CI errors encountered with setuptools_scm 8: https://github.com/pypa/setuptools_scm/issues/933