### PR TITLE
Remove the flang >= 11 pinning on windows, pin same as conda-forge

### DIFF
--- a/.github/scripts/set-conda-test-matrix.py
+++ b/.github/scripts/set-conda-test-matrix.py
@@ -14,7 +14,7 @@ blas_implementations = ['unset', 'Generic', 'OpenBLAS', 'Intel10_64lp']
 
 combinations = {'ubuntu': blas_implementations,
                 'macos': blas_implementations,
-                'windows': ['unset', 'Intel10_64lp'],
+                'windows': ['unset', 'Intel10_64lp', 'OpenBLAS'],
                }
 
 conda_jobs = []

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
               - 'ubuntu'
               - 'macos'
             python:
-              - '3.8'
+              - '3.10'
               - '3.11'
             bla_vendor: [ 'unset' ]
             include:

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,3 +1,4 @@
+set FC=%BUILD_PREFIX%\Library\bin\flang.exe
 set BLAS_ROOT=%PREFIX%
 set LAPACK_ROOT=%PREFIX%
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,14 +15,15 @@ requirements:
     - {{ compiler('c') }}
     - cmake >=3.14
     - make  # [linux]
-    - flang >=11  # [win]
+    # Always build against NETLIB ('Generic') LAPACK/Blas
+    - blas-devel * *netlib
+    # https://github.com/conda-forge/blas-feedstock/issues/106, conda-forge pins it themselves
+    - flang >=5.0.0,<6.0.0.a0  # [win]
 
   host:
     # Always build against NETLIB ('Generic') LAPACK/Blas
     # https://conda-forge.org/docs/maintainer/knowledge_base.html#blas
-    # deviating from above link: we have to specifiy netlib variant, because
-    # the mkl variant selected by default for older pythons on windows
-    # does not provide the generic headers
+    # deviating from above link: we have to pin ourselves, because we do not have the conda-forge build setups
     - libblas * *netlib
     - libcblas * *netlib
     - liblapack * *netlib
@@ -36,7 +37,8 @@ requirements:
   run:
     - python {{ PY_VER }}
     - {{ pin_compatible('numpy') }}
-    - libflang  # [win]
+    # see above
+    - libflang >=5.0.0,<6.0.0.a0  # [win]
 
 test:
   requires:


### PR DESCRIPTION
Workaround for using non-MKL due to https://github.com/python-control/Slycot/issues/219

See also https://github.com/conda-forge/blas-feedstock/issues/106
and https://github.com/conda-forge/slycot-feedstock/pull/65