### PR TITLE
Use conda-build for build matrix and pin like conda-forge

### DIFF
--- a/.github/conda-env/test-env.yml
+++ b/.github/conda-env/test-env.yml
@@ -1,7 +1,6 @@
 name: test-env
 dependencies:
   # in addtion to package dependencies and explicit LAPACK/BLAS implementations installed in workflow
-  - conda-build  # for conda index
   - scipy
   - matplotlib
   - pytest

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -132,7 +132,7 @@ jobs:
           path: slycot-wheels
 
   build-conda:
-    name: Build conda Py${{ matrix.python }}, ${{ matrix.os }}
+    name: Build conda, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     needs: build-sdist
     strategy:
@@ -143,7 +143,7 @@ jobs:
             - 'macos'
             - 'windows'
           python:
-            - '3.9'
+          # this is not the packaged version, just the version conda-build runs on.
             - '3.11'
 
     steps:
@@ -167,14 +167,14 @@ jobs:
         shell: bash -l {0}
         run: |
           set -e
-          numpyversion=$(python -c 'import numpy; print(numpy.version.version)')
-          conda mambabuild --python "${{ matrix.python }}" --numpy $numpyversion conda-recipe
+          conda mambabuild conda-recipe
           # preserve directory structure for custom conda channel
           find "${CONDA_PREFIX}/conda-bld" -maxdepth 2 -name 'slycot*.tar.bz2' | while read -r conda_pkg; do
             conda_platform=$(basename $(dirname "${conda_pkg}"))
             mkdir -p "slycot-conda-pkgs/${conda_platform}"
             cp "${conda_pkg}" "slycot-conda-pkgs/${conda_platform}/"
           done
+          conda index --no-progress ./slycot-conda-pkgs
       - name: Save to local conda pkg channel
         uses: actions/upload-artifact@v3
         with:
@@ -357,7 +357,6 @@ jobs:
               echo "libblas * *mkl" >> $CONDA_PREFIX/conda-meta/pinned
               ;;
           esac
-          conda index --no-progress ./slycot-conda-pkgs
           mamba install -c ./slycot-conda-pkgs slycot
           conda list
       - name: Slycot and python-control tests

--- a/README.rst
+++ b/README.rst
@@ -19,18 +19,18 @@ Riccati, Lyapunov, and Sylvester equations.
 Dependencies
 ------------
 
-Slycot supports Python versions 3.8 or later.
+Slycot supports Python versions 3.10 or later.
 
 To run the compiled Slycot package, the following must be installed as
 dependencies:
 
-- Python 3.8+
+- Python 3.10+
 - NumPy
 
 If you are compiling and installing Slycot from source, you will need the
 following dependencies:
 
-- Python 3.8+
+- Python 3.10+
 - NumPy
 - scikit-build
 - CMake
@@ -189,8 +189,6 @@ A similar method can be used for Linux and macOS, but is detailed here
 for Windows.  This method uses conda and conda-forge to get most build
 dependencies, *except* for the C compiler.
 
-This procedure has been tested on Python 3.8.
-
 1. Install `Microsoft Visual Studio`_.
 2. Unpack the source code to a directory of your choice,
 3. Create a command shell setup that can run the conda commands and the Visual
@@ -199,7 +197,7 @@ This procedure has been tested on Python 3.8.
    following commands to build and install Slycot (this example creates a
    Python 3.8 environment)::
 
-        conda create --channel conda-forge --name build-slycot python=3.8 numpy scipy libblas=*=*netlib liblapack=*=*netlib scikit-build flang pytest
+        conda create --channel conda-forge --name build-slycot python=3.10 numpy scipy libblas=*=*netlib liblapack=*=*netlib scikit-build flang pytest
         conda activate build-slycot
 
         pip install -v .

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,3 +1,5 @@
+:: correct FC, apparently pointed to host prefix??
+set FC=%BUILD_PREFIX%\Library\bin\flang.exe
 set BLAS_ROOT=%PREFIX%
 set LAPACK_ROOT=%PREFIX%
 

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,49 @@
+# https://github.com/conda-forge/blas-feedstock/issues/106#issuecomment-1771747983
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+
+
+# zip_keys Python/Numpy matrix to build for
+python:
+    - 3.10.* *_cpython
+    - 3.11.* *_cpython
+# 3.12 is already building in conda-forge/slycot-feedstock, but they did not publish everything yet
+#    - 3.12.* *_cpython
+numpy:
+    - 1.22
+    - 1.23
+#    - 1.23
+
+zip_keys:
+  -
+    - python
+    - numpy
+
+# Compiler selection
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+  - vs2019                     # [win and x86_64]
+  - vs2022                     # [win and arm64]
+c_compiler_version:            # [unix]
+  - 12                         # [linux]
+  - 16                         # [osx]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [linux64 or (osx and x86_64)]
+  - gfortran                   # [aarch64 or ppc64le or armv7l or s390x]
+  - flang                      # [win64]
+fortran_compiler_version:      # [unix or win64]
+  - 12                         # [linux]
+  - 12                         # [osx]
+  - 5                          # [win64]
+
+# Pinning
+
+# blas
+libblas:
+  - 3.9 *netlib
+libcblas:
+  - 3.9 *netlib
+liblapack:
+  - 3.9 *netlib
+liblapacke:
+  - 3.9 *netlib

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -11,32 +11,23 @@ build:
 
 requirements:
   build:
-    - {{ compiler('fortran') }}  # [not win]
+    - {{ compiler('fortran') }}
     - {{ compiler('c') }}
     - cmake >=3.14
     - make  # [linux]
-    - flang >=11  # [win]
-
   host:
-    # Always build against NETLIB ('Generic') LAPACK/Blas
-    # https://conda-forge.org/docs/maintainer/knowledge_base.html#blas
-    # deviating from above link: we have to specifiy netlib variant, because
-    # the mkl variant selected by default for older pythons on windows
-    # does not provide the generic headers
-    - libblas * *netlib
-    - libcblas * *netlib
-    - liblapack * *netlib
+    - libblas
+    - libcblas
+    - liblapack
     - python
-    - numpy >=1.19,!=1.23.0
-    - pip
+    - numpy
     - scikit-build >=0.15
+    - pip
     - setuptools >=45
     - setuptools_scm >=7
-
   run:
     - python {{ PY_VER }}
     - {{ pin_compatible('numpy') }}
-    - libflang  # [win]
 
 test:
   requires:


### PR DESCRIPTION
Supersedes #220 

Workaround for using non-MKL due to https://github.com/python-control/Slycot/issues/219

Brings our source directory recipe closer to the conda-forge environment.

See also https://github.com/conda-forge/blas-feedstock/issues/106
and https://github.com/conda-forge/slycot-feedstock/pull/65