### PR TITLE
Upgrade GitHub action dependencies: upload-artifact, download-artifact

### DIFF
--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -126,7 +126,7 @@ jobs:
           mkdir -p ${wheeldir}
           cp ./slycot*.whl ${wheeldir}/
       - name: Save wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -176,7 +176,7 @@ jobs:
           done
           python -m conda_index ./slycot-conda-pkgs
       - name: Save to local conda pkg channel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
@@ -192,7 +192,7 @@ jobs:
       - name: Checkout Slycot
         uses: actions/checkout@v3
       - name: Download wheels (if any)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -210,7 +210,7 @@ jobs:
       - name: Checkout Slycot
         uses: actions/checkout@v3
       - name: Download conda packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
@@ -272,7 +272,7 @@ jobs:
               exit 1 ;;
           esac
       - name: Download wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-wheels
           path: slycot-wheels
@@ -331,7 +331,7 @@ jobs:
           channel-priority: strict
           auto-activate-base: false
       - name: Download conda packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -128,8 +128,9 @@ jobs:
       - name: Save wheel
         uses: actions/upload-artifact@v4
         with:
-          name: slycot-wheels
+          name: slycot-wheels-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.bla_vendor }}
           path: slycot-wheels
+          retention-days: 5
 
   build-conda:
     name: Build conda, ${{ matrix.os }}
@@ -178,8 +179,9 @@ jobs:
       - name: Save to local conda pkg channel
         uses: actions/upload-artifact@v4
         with:
-          name: slycot-conda-pkgs
+          name: slycot-conda-pkgs-${{ matrix.os }}-${{ matrix.python }}
           path: slycot-conda-pkgs
+          retention-days: 5
 
   create-wheel-test-matrix:
     name: Create wheel test matrix
@@ -189,6 +191,11 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: slycot-wheels
+          pattern: slycot-wheels-*
       - name: Checkout Slycot
         uses: actions/checkout@v3
       - name: Download wheels (if any)
@@ -207,6 +214,11 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: slycot-conda-pkgs
+          pattern: slycot-conda-pkgs-*
       - name: Checkout Slycot
         uses: actions/checkout@v3
       - name: Download conda packages


### PR DESCRIPTION
Following deprecation notice at https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This pull request is similar to https://github.com/python-control/python-control/pull/1046