### PR TITLE
Constrain NumPy version to 1.X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "scikit-build>=0.15",
     "cmake>=3.14",
-    "numpy >= 1.23.1"]
+    "numpy>=1.23.1,<2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -37,7 +37,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy >= 1.23.1",
+    "numpy>=1.23.1,<2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
It seems that the Slycot wheels on PyPI were built with NumPy 1.X, but the `pyproject.toml` allows NumPy 2.X to be installed.

This means that if I create a fresh virtual environment and install Slycot, then it will pull NumPy 2.X, which makes the Slycot import fail.

I've added the version constraint in this PR, but if this is not what you had in mind, feel free to just close without merging.