### PR TITLE
CI: skip docstrings_test.py and add defaults channel

### DIFF
--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -18,6 +18,7 @@ donttest="$donttest or test_default_deprecation"
 pytest control/tests \
         --cov=$slycot_libdir \
         --cov-config=${slycot_srcdir}/.coveragerc \
+        --ignore=control/tests/docstrings_test.py \
         -k "not ($donttest)"
 mv .coverage ${slycot_srcdir}/.coverage.control
 popd

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -222,7 +222,10 @@ jobs:
           name: slycot-wheels
           path: slycot-wheels
       - id: set-matrix
-        run: echo "matrix=$(python3 .github/scripts/set-pip-test-matrix.py)" >> $GITHUB_OUTPUT
+        run: |
+          TEMPFILE="$(mktemp)"
+          python3 .github/scripts/set-pip-test-matrix.py | tee $TEMPFILE
+          echo "matrix=$(cat $TEMPFILE)" >> $GITHUB_OUTPUT
 
   create-conda-test-matrix:
     name: Create conda test matrix
@@ -245,7 +248,10 @@ jobs:
           name: slycot-conda-pkgs
           path: slycot-conda-pkgs
       - id: set-matrix
-        run: echo "matrix=$(python3 .github/scripts/set-conda-test-matrix.py)" >> $GITHUB_OUTPUT
+        run: |
+          TEMPFILE="$(mktemp)"
+          python3 .github/scripts/set-conda-test-matrix.py | tee $TEMPFILE
+          echo "matrix=$(cat $TEMPFILE)" >> $GITHUB_OUTPUT
 
 
   test-wheel:

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -179,6 +179,7 @@ jobs:
           environment-file: .github/conda-env/build-env.yml
           miniforge-version: latest
           channel-priority: strict
+          channels: conda-forge,defaults
           auto-update-conda: false
           auto-activate-base: false
       - name: Conda build
@@ -356,6 +357,7 @@ jobs:
           miniforge-version: latest
           activate-environment: test-env
           environment-file: slycot-src/.github/conda-env/test-env.yml
+          channels: conda-forge,defaults
           channel-priority: strict
           auto-activate-base: false
       - name: Download conda packages


### PR DESCRIPTION
`numpydoc` recently became required [in docstrings_test.py of python-control](https://github.com/python-control/python-control/blob/d11f05dbadd8218b5d8285d32115f1841e3a2ce5/control/tests/docstrings_test.py#L23). Slycot CI jobs include python-control tests [and skip irrelevant ones](https://github.com/python-control/Slycot/blob/bbfe718e5e32934ac64c0ac90ff08a2d18c7f389/.github/scripts/run-tests.sh#L14-L21). This PR skips docstrings_test.py because docstring consistency tests of python-control are not relevant here, and doing so also avoids the need to install numpydoc in these CI jobs.

This PR also add explicit miniconda channels as in
* https://github.com/python-control/python-control/pull/1129
* https://github.com/python-control/python-control/pull/1128