### PR TITLE
Get conda builds in GIthub workflow mostly working

### DIFF
--- a/.github/conda-env/build-env.yml
+++ b/.github/conda-env/build-env.yml
@@ -1,4 +1,0 @@
-name: build-env
-dependencies:
-  - boa
-  - numpy

--- a/.github/conda-env/test-env.yml
+++ b/.github/conda-env/test-env.yml
@@ -1,0 +1,9 @@
+name: test-env
+dependencies:
+  # in addtion to package dependencies and explicit LAPACK/BLAS implementations installed in workflow
+  - scipy
+  - matplotlib
+  - pytest
+  - pytest-cov
+  - pytest-timeout
+  - coverage

--- a/.github/conda-env/test-env.yml
+++ b/.github/conda-env/test-env.yml
@@ -1,9 +1,0 @@
-name: test-env
-dependencies:
-  # in addtion to package dependencies and explicit LAPACK/BLAS implementations installed in workflow
-  - scipy
-  - matplotlib
-  - pytest
-  - pytest-cov
-  - pytest-timeout
-  - coverage

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -16,6 +16,7 @@ donttest="test_root_locus_zoom or test_sisotool"
 # don't care about deprecation warnings here
 donttest="$donttest or test_default_deprecation"
 pytest control/tests \
+        -m slycot \
         --cov=$slycot_libdir \
         --cov-config=${slycot_srcdir}/.coveragerc \
         --ignore=control/tests/docstrings_test.py \

--- a/.github/scripts/set-conda-test-matrix.py
+++ b/.github/scripts/set-conda-test-matrix.py
@@ -16,7 +16,7 @@ combinations = {'ubuntu': ['unset', 'Generic', 'OpenBLAS', 'Intel10_64lp'],
                }
 
 conda_jobs = []
-for conda_pkg_file in Path("slycot-conda-pkgs").glob("*/*.tar.bz2"):
+for conda_pkg_file in Path("slycot-conda-pkgs").glob("*/*.conda"):
     cos = osmap[conda_pkg_file.parent.name.split("-")[0]]
     m = re.search(r'py(\d)(\d+)_', conda_pkg_file.name)
     pymajor, pyminor = int(m[1]), int(m[2])
@@ -27,6 +27,9 @@ for conda_pkg_file in Path("slycot-conda-pkgs").glob("*/*.tar.bz2"):
                 'python': cpy,
                 'blas_lib':  cbl}
         conda_jobs.append(cjob)
+
+if not conda_jobs:
+    raise SystemExit("No conda packages found")
 
 matrix = { 'include': conda_jobs }
 print(json.dumps(matrix))

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -162,7 +162,6 @@ jobs:
             - 'macos'
             - 'windows'
           python:
-            - '3.10'
             - '3.13'
 
     steps:
@@ -174,14 +173,31 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python }}
           activate-environment: build-env
-          miniforge-version: latest
-          conda-build-version: 25.7.0
           channel-priority: strict
+          channels: defaults
+          conda-build-version: 25.7.0
+          miniforge-version: latest
+          python-version: ${{ matrix.python }}
       - name: Conda build
+        shell: bash -el {0}
         run: |
+          set -e
           conda build conda-recipe --python ${{ matrix.python }}
+          # preserve directory structure for custom conda channel
+          CONDA_ROOT=$(conda info --base)
+          find "${CONDA_ROOT}/conda-bld" -maxdepth 2 -name 'slycot*.conda' | while read -r conda_pkg; do
+            conda_platform=$(basename $(dirname "${conda_pkg}"))
+            mkdir -p "slycot-conda-pkgs/${conda_platform}"
+            cp "${conda_pkg}" "slycot-conda-pkgs/${conda_platform}/"
+          done
+          conda index ./slycot-conda-pkgs
+      - name: Save to local conda pkg channel
+        uses: actions/upload-artifact@v4
+        with:
+          name: slycot-conda-pkgs-${{ matrix.os }}-${{ matrix.python }}
+          path: slycot-conda-pkgs
+          retention-days: 5
 
 
   create-wheel-test-matrix:
@@ -342,13 +358,12 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python }}
-          miniforge-version: latest
           activate-environment: test-env
-          environment-file: slycot-src/.github/conda-env/test-env.yml
-          channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          channels: defaults
+          environment-file: slycot-src/.github/conda-env/test-env.yml
+          miniforge-version: latest
+          python-version: ${{ matrix.python }}
       - name: Download conda packages
         uses: actions/download-artifact@v4
         with:
@@ -386,6 +401,7 @@ jobs:
           flag-name: wheel-${{ matrix.packagekey }}-${{matrix.blas_lib}}
           parallel: true
           file: slycot-src/coverage.xml
+
 
   coveralls-final:
     name: Finalize parallel coveralls

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           python-version: ${{ matrix.python }}
           activate-environment: build-env
           miniforge-version: latest

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           activate-environment: build-env
           channel-priority: strict
-          channels: defaults
+          channels: conda-forge,defaults
           conda-build-version: 25.7.0
           miniforge-version: latest
           python-version: ${{ matrix.python }}
@@ -360,7 +360,7 @@ jobs:
         with:
           activate-environment: test-env
           channel-priority: strict
-          channels: defaults
+          channels: conda-forge,defaults
           environment-file: slycot-src/.github/conda-env/test-env.yml
           miniforge-version: latest
           python-version: ${{ matrix.python }}

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -153,6 +153,7 @@ jobs:
   build-conda:
     name: Build conda, ${{ matrix.os }} ${{ matrix.python }}
     runs-on: ${{ matrix.os }}-latest
+    needs: build-sdist
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -173,12 +173,11 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          activate-environment: build-env
-          channel-priority: strict
-          channels: conda-forge,defaults
-          conda-build-version: 25.7.0
-          miniforge-version: latest
           python-version: ${{ matrix.python }}
+          activate-environment: build-env
+          miniforge-version: latest
+          conda-build-version: 25.7.0
+          channel-priority: strict
       - name: Conda build
         shell: bash -el {0}
         run: |
@@ -358,12 +357,13 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          activate-environment: test-env
-          channel-priority: strict
-          channels: conda-forge,defaults
-          environment-file: slycot-src/.github/conda-env/test-env.yml
-          miniforge-version: latest
           python-version: ${{ matrix.python }}
+          miniforge-version: latest
+          activate-environment: test-env
+          environment-file: slycot-src/.github/conda-env/test-env.yml
+          channels: conda-forge,defaults
+          channel-priority: strict
+          auto-activate-base: false
       - name: Download conda packages
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/slycot-build-and-test.yml
+++ b/.github/workflows/slycot-build-and-test.yml
@@ -151,9 +151,8 @@ jobs:
           retention-days: 5
 
   build-conda:
-    name: Build conda, ${{ matrix.os }}
+    name: Build conda, ${{ matrix.os }} ${{ matrix.python }}
     runs-on: ${{ matrix.os }}-latest
-    needs: build-sdist
     strategy:
         fail-fast: false
         matrix:
@@ -162,8 +161,8 @@ jobs:
             - 'macos'
             - 'windows'
           python:
-          # this is not the packaged version, just the version conda-build runs on.
-            - '3.11'
+            - '3.10'
+            - '3.13'
 
     steps:
       - name: Checkout Slycot
@@ -176,30 +175,13 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           activate-environment: build-env
-          environment-file: .github/conda-env/build-env.yml
           miniforge-version: latest
+          conda-build-version: 25.7.0
           channel-priority: strict
-          channels: conda-forge,defaults
-          auto-update-conda: false
-          auto-activate-base: false
       - name: Conda build
-        shell: bash -el {0}
         run: |
-          set -e
-          conda build conda-recipe
-          # preserve directory structure for custom conda channel
-          find "${CONDA_PREFIX}/conda-bld" -maxdepth 2 -name 'slycot*.tar.bz2' | while read -r conda_pkg; do
-            conda_platform=$(basename $(dirname "${conda_pkg}"))
-            mkdir -p "slycot-conda-pkgs/${conda_platform}"
-            cp "${conda_pkg}" "slycot-conda-pkgs/${conda_platform}/"
-          done
-          python -m conda_index ./slycot-conda-pkgs
-      - name: Save to local conda pkg channel
-        uses: actions/upload-artifact@v4
-        with:
-          name: slycot-conda-pkgs-${{ matrix.os }}-${{ matrix.python }}
-          path: slycot-conda-pkgs
-          retention-days: 5
+          conda build conda-recipe --python ${{ matrix.python }}
+
 
   create-wheel-test-matrix:
     name: Create wheel test matrix

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,5 +1,3 @@
-:: correct FC, apparently pointed to host prefix??
-set FC=%BUILD_PREFIX%\Library\bin\flang.exe
 set BLAS_ROOT=%PREFIX%
 set LAPACK_ROOT=%PREFIX%
 

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,46 +1,47 @@
-# https://github.com/conda-forge/blas-feedstock/issues/106#issuecomment-1771747983
-# https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
-# https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/migrations/python312.yaml
-
-# zip_keys Python/Numpy matrix to build for
-python:
-    - 3.10.* *_cpython
-    - 3.12.* *_cpython
-numpy:
-    - 1.23
-    - 1.26
-
-zip_keys:
-  -
-    - python
-    - numpy
-
-# Compiler selection
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0' # [osx]
+MACOSX_SDK_VERSION:
+- '11.0' # [osx]
 c_compiler:
-  - gcc                        # [linux]
-  - clang                      # [osx]
-  - vs2019                     # [win and x86_64]
-  - vs2022                     # [win and arm64]
-c_compiler_version:            # [unix]
-  - 12                         # [linux]
-  - 16                         # [osx]
-fortran_compiler:              # [unix or win64]
-  - gfortran                   # [linux64 or (osx and x86_64)]
-  - gfortran                   # [aarch64 or ppc64le or armv7l or s390x]
-  - flang                      # [win64]
-fortran_compiler_version:      # [unix or win64]
-  - 12                         # [linux]
-  - 12                         # [osx]
-  - 5                          # [win64]
-
-# Pinning
-
-# blas
+- vs2022 # [win64]
+- gcc # [linux]
+- clang # [osx]
+c_compiler_version:
+- '14' # [linux]
+- '19' # [osx]
+c_stdlib:
+- vs # [win64]
+- sysroot #[linux]
+- macosx_deployment_target # [osx]
+c_stdlib_version:
+- '2.17' # [linux]
+- '11.0' # [osx]
+cdt_name:
+- conda # [linux]
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- flang # [win64]
+- gfortran # [linux or osx]
+fortran_compiler_version:
+- '5' # [win64]
+- '14' # [linux or osx]
 libblas:
-  - 3.9 *netlib
+- 3.9 *netlib
 libcblas:
-  - 3.9 *netlib
+- 3.9 *netlib
 liblapack:
-  - 3.9 *netlib
-liblapacke:
-  - 3.9 *netlib
+- 3.9 *netlib
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -11,8 +11,13 @@ build:
 
 requirements:
   build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - scikit-build >=0.15                    # [build_platform != target_platform]
     - {{ compiler('fortran') }}
     - {{ compiler('c') }}
+    - {{ stdlib("c") }}
     - cmake >=3.14
     - make  # [linux]
   host:
@@ -26,8 +31,7 @@ requirements:
     - setuptools >=45
     - setuptools_scm >=7
   run:
-    - python {{ PY_VER }}
-    - {{ pin_compatible('numpy') }}
+    - python
 
 test:
   requires:


### PR DESCRIPTION
meta.yaml and conda_build_config.yaml copied and adapted from conda-forge/slycot-feedstock.

The failures in testing on OSX seem to be due to something with coveralls; the failures happen (at least on my repo - tests yet to run here) at coverage-collection time, and this happens for both conda and wheel tests.  I didn't change the wheel build, and these OSX wheel tests passed completely in the most recent merged PR gh-294.

I tried to get rid of the various conda warnings encountered through the build, but ended up with a free-threaded python (!) when testing against 3.13; when I tried to change `meta.yaml` to prevent that, the build broke in a mysterious way.